### PR TITLE
feat/login

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.myfave.api.domain.auth.controller;
 
+import com.myfave.api.domain.auth.dto.request.LoginRequest;
 import com.myfave.api.domain.auth.dto.request.SignUpRequest;
+import com.myfave.api.domain.auth.dto.response.LoginResponse;
 import com.myfave.api.domain.auth.dto.response.SignUpResponse;
 import com.myfave.api.domain.auth.service.AuthService;
 import com.myfave.api.global.common.ApiResponse;
@@ -20,5 +22,10 @@ public class AuthController {
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
         return ApiResponse.created("회원가입이 완료되었습니다.", authService.signUp(request));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return new ApiResponse<>(200, "로그인 성공", authService.login(request));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/request/LoginRequest.java
@@ -1,10 +1,16 @@
 package com.myfave.api.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-
+// 로그인시 정보 유효성 검사
 @Getter
 public class LoginRequest {
 
+    @NotBlank
+    @Email
     private String email;
+
+    @NotBlank
     private String password;
 }

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,24 @@
+package com.myfave.api.domain.auth.dto.response;
+
+import com.myfave.api.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long userId;
+    private final String nickname;
+
+    private LoginResponse(String accessToken, String refreshToken, Long userId, String nickname) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+
+    public static LoginResponse of(String accessToken, String refreshToken, User user) {
+        return new LoginResponse(accessToken, refreshToken, user.getUserId(), user.getNickname());
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
@@ -1,16 +1,23 @@
 package com.myfave.api.domain.auth.service;
 
+import com.myfave.api.domain.auth.dto.request.LoginRequest;
 import com.myfave.api.domain.auth.dto.request.SignUpRequest;
+import com.myfave.api.domain.auth.dto.response.LoginResponse;
 import com.myfave.api.domain.auth.dto.response.SignUpResponse;
 import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +27,11 @@ public class AuthService {
     private final UserRepository userRepository;
     private final AuthenticationManager authenticationManager;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Value("${jwt.refresh-token-expiry}")
+    private long refreshTokenExpiry;
 
     @Transactional
     public SignUpResponse signUp(SignUpRequest request) {
@@ -42,5 +54,26 @@ public class AuthService {
                 .build();
 
         return SignUpResponse.from(userRepository.save(user));
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+        // 토큰 발급
+        String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getUserId());
+
+        redisTemplate.opsForValue().set( // radis를 key-value 형태로 사용하겠다.
+                "refresh:" + user.getUserId(), // key
+                refreshToken, // value
+                refreshTokenExpiry, // 유효기간
+                TimeUnit.MILLISECONDS// 단위
+        );
+
+        return LoginResponse.of(accessToken, refreshToken, user);
     }
 }


### PR DESCRIPTION
#17


- [X]  LoginRequest.java   : @Email, @NotBlank 유효성 검증 추가     

- [X]  LoginResponse.java  : 신규 생성 — accessToken, refreshToken, userId, nickname 
- [X]   AuthService.java    : login() 메서드 추가                                     
- [X]  AuthController.java : POST /api/v1/auth/login 엔드포인트 추가                 

  로그인 흐름:
  1. 이메일로 유저 조회 → 없으면 AUTH_INVALID_CREDENTIALS
  2. passwordEncoder.matches()로 비밀번호 검증 → 불일치 시 AUTH_INVALID_CREDENTIALS
  3. Access Token + Refresh Token 발급
  4. Redis에 refresh:{userId} 키로 Refresh Token 저장 (TTL 14일)
  5. 응답 반환
  
  그 외 주석으로 흐름 작성해놨음