### PR TITLE
feat: 회원 정보 조회/수정 API

### DIFF
--- a/backend/src/main/java/com/myfave/api/MyfaveApplication.java
+++ b/backend/src/main/java/com/myfave/api/MyfaveApplication.java
@@ -2,10 +2,8 @@ package com.myfave.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class MyfaveApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
@@ -1,9 +1,13 @@
 package com.myfave.api.domain.user.controller;
 
+import com.myfave.api.domain.user.dto.response.UserResponse;
 import com.myfave.api.domain.user.service.UserService;
+import com.myfave.api.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.myfave.api.domain.user.dto.request.UserUpdateRequest;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/users")
@@ -11,4 +15,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserResponse>> getUser(
+            @PathVariable Long userId) {
+
+        UserResponse response = userService.getUser(userId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @PatchMapping("/{userId}/edit")
+    public ResponseEntity<ApiResponse<UserResponse>> updateUser(
+            @PathVariable Long userId,
+            @RequestBody @Valid UserUpdateRequest request) {
+
+        UserResponse response = userService.updateUser(userId, request);
+        return ResponseEntity.ok(
+                new ApiResponse<>(200, "회원 정보가 수정되었습니다.", response));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/user/dto/request/UserUpdateRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.myfave.api.domain.user.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserUpdateRequest {
+
+    @Size(min = 2, max = 12, message = "닉네임은 2~12자여야 합니다.")
+    private String nickname;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8~20자여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]+$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String password;
+
+    @Size(min = 2, max = 20, message = "이름은 2~20자여야 합니다.")
+    private String name;
+
+    @Pattern(
+            regexp = "^010-\\d{4}-\\d{4}$",
+            message = "전화번호는 010-XXXX-XXXX 형식이어야 합니다."
+    )
+    private String phone;
+}

--- a/backend/src/main/java/com/myfave/api/domain/user/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/dto/response/UserResponse.java
@@ -4,6 +4,8 @@ import com.myfave.api.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.ZonedDateTime;
+
 @Getter
 @AllArgsConstructor
 public class UserResponse {
@@ -13,6 +15,8 @@ public class UserResponse {
     private String name;
     private String nickname;
     private String phone;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
 
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -20,7 +24,9 @@ public class UserResponse {
                 user.getEmail(),
                 user.getName(),
                 user.getNickname(),
-                user.getPhone()
+                user.getPhone(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
         );
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/user/entity/User.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/entity/User.java
@@ -45,4 +45,15 @@ public class User extends BaseEntity {
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updatePhone(String phone) {
+        this.phone = phone;
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/service/UserService.java
@@ -1,9 +1,15 @@
 package com.myfave.api.domain.user.service;
 
+import com.myfave.api.domain.user.dto.response.UserResponse;
+import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.myfave.api.domain.user.dto.request.UserUpdateRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Service
 @RequiredArgsConstructor
@@ -11,4 +17,41 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserResponse getUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateUser(Long userId, UserUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (request.getNickname() != null && !request.getNickname().equals(user.getNickname())) {
+            if (userRepository.existsByNickname(request.getNickname())) {
+                throw new CustomException(ErrorCode.USER_DUPLICATE_NICKNAME);
+            }
+            user.updateNickname(request.getNickname());
+        }
+
+        if (request.getPhone() != null && !request.getPhone().equals(user.getPhone())) {
+            if (userRepository.existsByPhone(request.getPhone())) {
+                throw new CustomException(ErrorCode.USER_DUPLICATE_PHONE);
+            }
+            user.updatePhone(request.getPhone());
+        }
+
+        if (request.getName() != null) {
+            user.updateName(request.getName());
+        }
+
+        if (request.getPassword() != null) {
+            user.updatePassword(passwordEncoder.encode(request.getPassword()));
+        }
+
+        return UserResponse.from(user);
+    }
 }

--- a/backend/src/main/java/com/myfave/api/global/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/JpaAuditingConfig.java
@@ -1,0 +1,19 @@
+package com.myfave.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "zonedDateTimeProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    public DateTimeProvider zonedDateTimeProvider() {
+        return () -> Optional.of(ZonedDateTime.now());
+    }
+}

--- a/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
@@ -38,6 +38,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        e.printStackTrace();
         return ResponseEntity
                 .status(500)
                 .body(ApiResponse.error(ErrorCode.COMMON_INTERNAL_ERROR));

--- a/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
@@ -38,7 +38,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        e.printStackTrace();
         return ResponseEntity
                 .status(500)
                 .body(ApiResponse.error(ErrorCode.COMMON_INTERNAL_ERROR));


### PR DESCRIPTION
- 회원 정보 조회 및 수정 API 구현

## ZonedDateTime Auditing 이슈 해결
- 문제: BaseEntity의 createdAt/updatedAt이 ZonedDateTime인데, Spring Data JPA Auditing의 @LastModifiedDate가 기본적으로 LocalDateTime을 생성하여 타입 충돌 발생 (PATCH 등 데이터 수정 시 500 에러)
- 원인: @EnableJpaAuditing의 기본 DateTimeProvider가 LocalDateTime만 지원
- 해결: JpaAuditingConfig 생성하여 ZonedDateTime을 반환하는 커스텀 DateTimeProvider 등록, MyfaveApplication에서 기존 @EnableJpaAuditing 제거"