### PR TITLE
15 feat 인플루언서용 상품 등록수정 api

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.myfave.api.domain.product.controller;
 
 import com.myfave.api.domain.product.dto.request.ProductRequest;
+import com.myfave.api.domain.product.dto.request.ProductUpdateRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
@@ -55,5 +56,18 @@ public class ProductController {
         Long productId = productService.createProduct(userId, request, images);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("Created", Map.of("id", productId)));
+    }
+
+    // 3-4. 상품 수정 (인플루언서 전용)
+    @PatchMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Map<String, Long>>> updateProduct(
+            @PathVariable Long productId,
+            //수정에서는 필수값 아니라 false 처리
+            @RequestPart(required = false) @Valid ProductUpdateRequest request,
+            @RequestPart(required = false) List<MultipartFile> images) {
+        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
+        Long userId = 1L;
+        Long updatedId = productService.updateProduct(userId, productId, request, images);
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("id", updatedId)));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -1,9 +1,13 @@
 package com.myfave.api.domain.product.controller;
 
+import com.myfave.api.domain.product.dto.response.ProductListResponse;
+import com.myfave.api.domain.product.dto.response.ProductResponse;
+import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.service.ProductService;
+import com.myfave.api.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/products")
@@ -11,4 +15,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
     private final ProductService productService;
+
+    // 3-1. 상품 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(
+            @RequestParam(required = false) CategoryCode categoryCode,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String sort) {
+        ProductListResponse response = productService.getProducts(categoryCode, page, size, sort);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 3-2. 상품 상세 조회
+    @GetMapping("/{productId}")
+    public ResponseEntity<ApiResponse<ProductResponse.Detail>> getProduct(
+            @PathVariable Long productId) {
+        ProductResponse.Detail response = productService.getProduct(productId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -7,6 +7,9 @@ import com.myfave.api.domain.product.dto.response.ProductResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.service.ProductService;
 import com.myfave.api.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,7 +50,8 @@ public class ProductController {
     // 3-3. 상품 등록 (인플루언서 전용)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE) //이미지 파일 같이 받아야해서 일반 json 불가
     public ResponseEntity<ApiResponse<Map<String, Long>>> createProduct(
-            //상품정보 json
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ProductRequest.class)))
             @RequestPart @Valid ProductRequest request,
             //이미지 파일 목록
             @RequestPart List<MultipartFile> images) {
@@ -62,7 +66,8 @@ public class ProductController {
     @PatchMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Map<String, Long>>> updateProduct(
             @PathVariable Long productId,
-            //수정에서는 필수값 아니라 false 처리
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = ProductUpdateRequest.class)))
             @RequestPart(required = false) @Valid ProductUpdateRequest request,
             @RequestPart(required = false) List<MultipartFile> images) {
         // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -1,13 +1,21 @@
 package com.myfave.api.domain.product.controller;
 
+import com.myfave.api.domain.product.dto.request.ProductRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.service.ProductService;
 import com.myfave.api.global.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/products")
@@ -33,5 +41,19 @@ public class ProductController {
             @PathVariable Long productId) {
         ProductResponse.Detail response = productService.getProduct(productId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 3-3. 상품 등록 (인플루언서 전용)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE) //이미지 파일 같이 받아야해서 일반 json 불가
+    public ResponseEntity<ApiResponse<Map<String, Long>>> createProduct(
+            //상품정보 json
+            @RequestPart @Valid ProductRequest request,
+            //이미지 파일 목록
+            @RequestPart List<MultipartFile> images) {
+        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
+        Long userId = 1L;
+        Long productId = productService.createProduct(userId, request, images);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("Created", Map.of("id", productId)));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/request/ProductRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/request/ProductRequest.java
@@ -2,16 +2,33 @@ package com.myfave.api.domain.product.dto.request;
 
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.entity.ConditionCode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class ProductRequest {
 
+    @NotBlank(message = "상품명은 필수입니다")
+    @Size(max = 100, message = "상품명은 100자 이하입니다")
     private String productName;
-    private String shortReview;
+
+    @NotNull(message = "가격은 필수입니다")
+    @PositiveOrZero(message = "가격은 0 이상이어야 합니다")
     private Integer price;
+
     private String description;
+
+    @Size(max = 100, message = "한줄 소개는 100자 이하입니다")
+    private String shortReview;
+
     private String size;
-    private ConditionCode conditionCode;
+    //enum 타입, 문자열 자동 변환
+    @NotNull(message = "상품 상태는 필수입니다")
+    private ConditionCode condition;
+    //enum 타입, 문자열 자동 변환
+    @NotNull(message = "카테고리는 필수입니다")
     private CategoryCode categoryCode;
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/request/ProductUpdateRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,32 @@
+package com.myfave.api.domain.product.dto.request;
+
+import com.myfave.api.domain.product.entity.CategoryCode;
+import com.myfave.api.domain.product.entity.ConditionCode;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProductUpdateRequest {
+
+    @Size(max = 100, message = "상품명은 100자 이하입니다")
+    private String productName;
+
+    @PositiveOrZero(message = "가격은 0 이상이어야 합니다")
+    private Integer price;
+
+    private String description;
+
+    @Size(max = 100, message = "한줄 소개는 100자 이하입니다")
+    private String shortReview;
+
+    private String size;
+
+    private ConditionCode condition;
+
+    private CategoryCode categoryCode;
+
+    private List<Long> deleteImageIds;
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductListResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductListResponse.java
@@ -1,0 +1,30 @@
+package com.myfave.api.domain.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ProductListResponse {
+
+    private List<ProductResponse> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+
+    public static ProductListResponse from(Page<ProductResponse> productPage) {
+        return new ProductListResponse(
+                productPage.getContent(),
+                productPage.getNumber(),
+                productPage.getSize(),
+                productPage.getTotalElements(),
+                productPage.getTotalPages(),
+                productPage.hasNext()
+        );
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
@@ -3,32 +3,86 @@ package com.myfave.api.domain.product.dto.response;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.entity.ConditionCode;
 import com.myfave.api.domain.product.entity.Product;
+import com.myfave.api.domain.product.entity.ProductImage;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class ProductResponse {
 
-    private Long productId;
+    private Long id;
     private String productName;
-    private String shortReview;
     private Integer price;
-    private String size;
-    private ConditionCode conditionCode;
-    private CategoryCode categoryCode;
-    private Boolean isSoldout;
+    private String thumbnailUrl;
+    private Boolean isSoldOut;
 
-    public static ProductResponse from(Product product) {
+    public static ProductResponse from(Product product, String thumbnailUrl) {
         return new ProductResponse(
                 product.getProductId(),
                 product.getProductName(),
-                product.getShortReview(),
                 product.getPrice(),
-                product.getSize(),
-                product.getConditionCode(),
-                product.getCategoryCode(),
+                thumbnailUrl,
                 product.getIsSoldout()
         );
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Detail {
+        private Long id;
+        private String productName;
+        private String shortReview;
+        private Integer price;
+        private String description;
+        private String size;
+        private ConditionCode condition;
+        private CategoryCode categoryCode;
+        private Boolean isSoldOut;
+        private List<ImageDto> images;
+        private ZonedDateTime createdAt;
+
+        public static Detail from(Product product, List<ProductImage> images) {
+            List<ImageDto> imageDtos = images.stream()
+                    .map(ImageDto::from)
+                    .toList();
+
+            return Detail.builder()
+                    .id(product.getProductId())
+                    .productName(product.getProductName())
+                    .shortReview(product.getShortReview())
+                    .price(product.getPrice())
+                    .description(product.getDescription())
+                    .size(product.getSize())
+                    .condition(product.getConditionCode())
+                    .categoryCode(product.getCategoryCode())
+                    .isSoldOut(product.getIsSoldout())
+                    .images(imageDtos)
+                    .createdAt(product.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ImageDto {
+        private Long imageId;
+        private String imageUrl;
+        private Integer sortOrder;
+        private Boolean isMain;
+
+        public static ImageDto from(ProductImage image) {
+            return new ImageDto(
+                    image.getProductImgId(),
+                    image.getImageUrl(),
+                    image.getSortOrder(),
+                    image.getIsMain()
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -67,6 +67,20 @@ public class Product extends BaseEntity {
         this.isSoldout = false;
     }
 
+    //patch 보낸 것만 변경
+    // Entity 상태 변경 모아서 관리하려고 메서드 하나로 묶음
+    public void update(String productName, Integer price, String description,
+                       String shortReview, String size, ConditionCode conditionCode,
+                       CategoryCode categoryCode) {
+        if (productName != null) this.productName = productName;
+        if (price != null) this.price = price;
+        if (description != null) this.description = description;
+        if (shortReview != null) this.shortReview = shortReview;
+        if (size != null) this.size = size;
+        if (conditionCode != null) this.conditionCode = conditionCode;
+        if (categoryCode != null) this.categoryCode = categoryCode;
+    }
+
     public void markAsSoldout() {
         this.isSoldout = true;
     }

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
+
 @Entity
 @Table(name = "products")
 @Getter
@@ -49,6 +51,8 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private Boolean isSoldout = false;
 
+    private ZonedDateTime deletedAt;
+
     @Builder
     private Product(User user, String productName, String shortReview, Integer price,
                     String description, String size, ConditionCode conditionCode, CategoryCode categoryCode) {
@@ -65,5 +69,13 @@ public class Product extends BaseEntity {
 
     public void markAsSoldout() {
         this.isSoldout = true;
+    }
+
+    public void softDelete() {
+        this.deletedAt = ZonedDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductImageRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductImageRepository.java
@@ -14,4 +14,7 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
 
     // 대표 이미지
     Optional<ProductImage> findByProductAndIsMainTrue(Product product);
+
+    // 특정 이미지 ID 목록으로 삭제
+    void deleteAllByProductImgIdIn(List<Long> productImgIds);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -3,9 +3,12 @@ package com.myfave.api.domain.product.repository;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.entity.Product;
 import com.myfave.api.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
@@ -17,4 +20,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // 카테고리별 조회
     List<Product> findByCategoryCodeAndIsSoldoutFalse(CategoryCode categoryCode);
+
+    // 상품 목록 조회 (Soft Delete 제외, 전체 카테고리)
+    Page<Product> findByDeletedAtIsNull(Pageable pageable);
+
+    // 상품 목록 조회 (Soft Delete 제외, 특정 카테고리)
+    Page<Product> findByCategoryCodeAndDeletedAtIsNull(CategoryCode categoryCode, Pageable pageable);
+
+    // 상품 상세 조회 (Soft Delete 제외)
+    Optional<Product> findByProductIdAndDeletedAtIsNull(Long productId);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.myfave.api.domain.product.service;
 
 import com.myfave.api.domain.product.dto.request.ProductRequest;
+import com.myfave.api.domain.product.dto.request.ProductUpdateRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
@@ -107,6 +108,61 @@ public class ProductService {
                     .build();
 
             productImageRepository.save(productImage);
+        }
+
+        return product.getProductId();
+    }
+
+    // 3-4. 상품 수정 (인플루언서 전용)
+    @Transactional
+    public Long updateProduct(Long userId, Long productId, ProductUpdateRequest request,
+                              List<MultipartFile> newImages) {
+        validateInfluencer(userId);
+        //기존 product 가져오기 & 삭제된 상품 제외
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 상품 정보 수정 (보낸 필드만 변경)
+        if (request != null) {
+            product.update(
+                    request.getProductName(),
+                    request.getPrice(),
+                    request.getDescription(),
+                    request.getShortReview(),
+                    request.getSize(),
+                    request.getCondition(),
+                    request.getCategoryCode()
+            );
+
+            // 이미지 삭제
+            if (request.getDeleteImageIds() != null && !request.getDeleteImageIds().isEmpty()) {
+                productImageRepository.deleteAllByProductImgIdIn(request.getDeleteImageIds());
+            }
+        }
+
+        // 새 이미지 추가
+        if (newImages != null && !newImages.isEmpty()) {
+            //기존 이미지 정렬 순서 중 가장 큰 값 찾아서 그 다음값 배당 (순서 중복 이슈 방지)
+            int currentMaxOrder = productImageRepository.findByProductOrderBySortOrderAsc(product)
+                    .stream()
+                    .mapToInt(ProductImage::getSortOrder)
+                    .max()
+                    .orElse(0);
+
+            for (int i = 0; i < newImages.size(); i++) {
+                MultipartFile image = newImages.get(i);
+                // TODO: Sprint 2에서 S3 업로드로 교체
+                String imageUrl = "/images/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+                ProductImage productImage = ProductImage.builder()
+                        .product(product)
+                        .imageUrl(imageUrl)
+                        .sortOrder(currentMaxOrder + i + 1)
+                        .isMain(false)
+                        .build();
+
+                productImageRepository.save(productImage);
+            }
         }
 
         return product.getProductId();

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -1,5 +1,6 @@
 package com.myfave.api.domain.product.service;
 
+import com.myfave.api.domain.product.dto.request.ProductRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
@@ -7,17 +8,22 @@ import com.myfave.api.domain.product.entity.Product;
 import com.myfave.api.domain.product.entity.ProductImage;
 import com.myfave.api.domain.product.repository.ProductImageRepository;
 import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.domain.user.entity.User;
+import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +32,11 @@ public class ProductService {
 
     private final ProductRepository productRepository; //상품 데이터
     private final ProductImageRepository productImageRepository; //이미지 데이터
+    private final UserRepository userRepository;
+
+    //설정파일에서 읽어오는거라 인플루언서 아이디 application.yml 에서 변경 가능
+    @Value("${influencer.user-id}")
+    private Long influencerUserId;
 
     // 3-1. 상품 목록 조회
     public ProductListResponse getProducts(CategoryCode categoryCode, int page, int size, String sort) {
@@ -61,6 +72,53 @@ public class ProductService {
 
         return ProductResponse.Detail.from(product, images);
     }
+    // 3-3. 상품 등록 (인플루언서 전용)
+    @Transactional //쓰기 가능
+    public Long createProduct(Long userId, ProductRequest request, List<MultipartFile> images) {
+        validateInfluencer(userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Product product = Product.builder()
+                .user(user)
+                .productName(request.getProductName())
+                .shortReview(request.getShortReview())
+                .price(request.getPrice())
+                .description(request.getDescription())
+                .size(request.getSize())
+                .conditionCode(request.getCondition())
+                .categoryCode(request.getCategoryCode())
+                .build();
+
+        productRepository.save(product);
+
+        // 이미지 저장 (첫 번째 이미지가 메인)
+        for (int i = 0; i < images.size(); i++) {
+            MultipartFile image = images.get(i);
+            // TODO: Sprint 2에서 S3 업로드로 교체
+            String imageUrl = "/images/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+            ProductImage productImage = ProductImage.builder()
+                    .product(product)
+                    .imageUrl(imageUrl)
+                    .sortOrder(i + 1)
+                    .isMain(i == 0)
+                    .build();
+
+            productImageRepository.save(productImage);
+        }
+
+        return product.getProductId();
+    }
+
+    // 인플루언서 권한 검증
+    private void validateInfluencer(Long userId) {
+        if (!influencerUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+    }
+
     // 정렬 파라미터("price,asc" 등)를 JPA Sort 객체로 변환 (기본값: 최신순)
     private Sort resolveSort(String sort) {
         if (sort == null || sort.isBlank()) {

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -1,16 +1,78 @@
 package com.myfave.api.domain.product.service;
 
+import com.myfave.api.domain.product.dto.response.ProductListResponse;
+import com.myfave.api.domain.product.dto.response.ProductResponse;
+import com.myfave.api.domain.product.entity.CategoryCode;
+import com.myfave.api.domain.product.entity.Product;
+import com.myfave.api.domain.product.entity.ProductImage;
 import com.myfave.api.domain.product.repository.ProductImageRepository;
 import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductService {
 
-    private final ProductRepository productRepository;
-    private final ProductImageRepository productImageRepository;
+    private final ProductRepository productRepository; //상품 데이터
+    private final ProductImageRepository productImageRepository; //이미지 데이터
+
+    // 3-1. 상품 목록 조회
+    public ProductListResponse getProducts(CategoryCode categoryCode, int page, int size, String sort) {
+        Sort sorting = resolveSort(sort);
+        Pageable pageable = PageRequest.of(page, size, sorting);
+
+        Page<Product> productPage;
+        //1. 카테고리가 없거나 all 이면 전체에서 꺼내기
+        if (categoryCode == null || categoryCode == CategoryCode.ALL) {
+            productPage = productRepository.findByDeletedAtIsNull(pageable);
+        } else {
+            //2. 특정 카테고리가 있으면 그 카테고리만 꺼내기
+            productPage = productRepository.findByCategoryCodeAndDeletedAtIsNull(categoryCode, pageable);
+        }
+        // 꺼낸 상품에 각각 대표 이미지 붙이기
+        Page<ProductResponse> responsePage = productPage.map(product -> {
+            String thumbnailUrl = productImageRepository.findByProductAndIsMainTrue(product)
+                    .map(ProductImage::getImageUrl)
+                    .orElse(null);
+            return ProductResponse.from(product, thumbnailUrl);
+        });
+
+        return ProductListResponse.from(responsePage);
+    }
+
+    // 3-2. 상품 상세 조회
+    public ProductResponse.Detail getProduct(Long productId) {
+        // ID기반으로 찾고 못찾으면 404 에러
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        List<ProductImage> images = productImageRepository.findByProductOrderBySortOrderAsc(product);
+
+        return ProductResponse.Detail.from(product, images);
+    }
+    // 정렬 파라미터("price,asc" 등)를 JPA Sort 객체로 변환 (기본값: 최신순)
+    private Sort resolveSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+        String[] parts = sort.split(",");
+        if (parts.length != 2) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+        String field = parts[0].trim();
+        String direction = parts[1].trim().toLowerCase();
+        Sort.Direction dir = "asc".equals(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return Sort.by(dir, field);
+    }
 }

--- a/backend/src/main/java/com/myfave/api/global/config/WebConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/WebConfig.java
@@ -1,11 +1,28 @@
 package com.myfave.api.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    // Swagger UI가 multipart 요청 시 JSON 파트를 octet-stream으로 보내는 문제 해결
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(new ObjectMapper());
+        List<MediaType> supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(MediaType.APPLICATION_OCTET_STREAM);
+        converter.setSupportedMediaTypes(supportedMediaTypes);
+        converters.add(converter);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
## 📌 관련 이슈
Closes #15 

## 📝 작업 내용                                                                                                                                                                    
  - 상품 목록 조회(3-1), 상세 조회(3-2), 등록(3-3), 수정(3-4) API 구현                                                                                                               
  - API 명세서 기준 필드명 정리 (`id`, `thumbnailUrl`, `condition`, `imageId` 등)                                                                                                    
  - Swagger multipart JSON 파싱 이슈 해결                                                                                                                                            
                                                                                                                                                                                     
  ## Swagger multipart 이슈 해결                                                                                                                                                     
  Swagger UI에서 `POST /products`, `PATCH /products/{id}` 호출 시 500 에러 발생
                                                                                                                                                                                     
  **원인**: Swagger UI가 multipart 요청의 JSON 파트를 `application/json`이 아닌 `application/octet-stream`으로 전송 → Spring이 JSON 파싱 실패 (Swagger UI 자체 제한사항)             
                                                                                                                                                                                     
  **해결**: `WebConfig`에 `MappingJackson2HttpMessageConverter`의 지원 MediaType에 `application/octet-stream`을 추가 → octet-stream으로 들어온 JSON도 정상 파싱되도록 처리.          
  이미지(`MultipartFile`) 처리에는 영향 없음
                                                                                                                                                                                     
  ## 추후 작업 (TODO)
  - **이미지 URL**: 현재 `"/images/" + UUID + filename` 플레이스홀더 저장 → Sprint 2에서 S3 연동 예정
  - **userId 하드코딩**: 현재 `1L` 고정 → Sprint 4에서 JWT 인증 적용 예정                                                                                                            
                                                                                                                                                                                     
  ## ⚠️ 리뷰어에게 전달 사항                                                                                                                                                         
  - **WebConfig 변경**: 위 Swagger 이슈 해결용으로 `configureMessageConverters`를 추가,  기존 API 동작에 영향 없고 pull 받으면 자동 적용                    
  - **S3 미적용**: Sprint 2 태스크로 배정되어 있어 플레이스홀더로 대체 , 전환 시 Service 내부 URL 생성 로직만 변경하면 됨                                            
  - **JWT 미적용**: Sprint 4 범위라 임시값 처리했고 `// TODO` 주석으로 표시해둠!  