### PR TITLE
35 feat order 5 4 주문 상태 변경구매 확정 api 개발

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.myfave.api.domain.order.controller;
 
 import com.myfave.api.domain.order.dto.request.OrderCreateRequest;
+import com.myfave.api.domain.order.dto.response.OrderConfirmResponse;
 import com.myfave.api.domain.order.dto.response.OrderDetailResponse;
 import com.myfave.api.domain.order.dto.response.OrderListResponse;
 import com.myfave.api.domain.order.dto.response.OrderResponse;
@@ -122,6 +123,34 @@ public class OrderController {
 
         OrderDetailResponse response = orderService.getOrderDetail(userId, orderId);
 
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    /**
+     * 주문 상태 변경 - 구매확정 (5-4)
+     * PATCH /api/v1/orders/{orderId}/confirm
+     */
+    @Operation(
+            summary = "구매확정",
+            description = "배송완료(DELIVERY_COMPLETED) 상태의 주문을 구매확정(PURCHASE_CONFIRMED)으로 변경합니다.\n\n" +
+                          "- DELIVERY_COMPLETED 상태가 아니면 409 반환"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구매확정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인 주문이 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "구매확정 가능한 상태가 아님")
+    })
+    @PatchMapping("/{orderId}/confirm")
+    public ResponseEntity<ApiResponse<OrderConfirmResponse>> confirmOrder(
+            @AuthenticationPrincipal Long userId,
+
+            // @PathVariable: URL 경로의 {orderId} 값을 파라미터로 바인딩
+            @PathVariable Long orderId) {
+
+        OrderConfirmResponse response = orderService.confirmOrder(userId, orderId);
+
+        // ApiResponse.ok(): code=200, message="OK", data=response
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/order/dto/response/OrderConfirmResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/dto/response/OrderConfirmResponse.java
@@ -1,0 +1,28 @@
+package com.myfave.api.domain.order.dto.response;
+
+import com.myfave.api.domain.order.entity.Order;
+import com.myfave.api.domain.order.entity.OrderStatus;
+import lombok.Getter;
+
+@Getter
+public class OrderConfirmResponse {
+
+    // 구매확정된 주문 ID
+    private final Long orderId;
+
+    // 변경된 주문 상태 (PURCHASE_CONFIRMED)
+    private final OrderStatus orderStatus;
+
+    private OrderConfirmResponse(Long orderId, OrderStatus orderStatus) {
+        this.orderId = orderId;
+        this.orderStatus = orderStatus;
+    }
+
+    // Order 엔티티에서 필요한 필드만 추출하여 DTO 생성
+    public static OrderConfirmResponse from(Order order) {
+        return new OrderConfirmResponse(
+                order.getOrderId(),
+                order.getOrderStatus()
+        );
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/entity/Order.java
@@ -58,6 +58,10 @@ public class Order extends BaseEntity {
         this.orderStatus = OrderStatus.CANCELLED;
     }
 
+    public void confirm() {
+        this.orderStatus = OrderStatus.PURCHASE_CONFIRMED;
+    }
+
     public void refund() {
         this.orderStatus = OrderStatus.REFUNDED;
     }

--- a/backend/src/main/java/com/myfave/api/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/entity/Order.java
@@ -58,6 +58,10 @@ public class Order extends BaseEntity {
         this.orderStatus = OrderStatus.CANCELLED;
     }
 
+    public void completeDelivery() {
+        this.orderStatus = OrderStatus.DELIVERY_COMPLETED;
+    }
+
     public void confirm() {
         this.orderStatus = OrderStatus.PURCHASE_CONFIRMED;
     }

--- a/backend/src/main/java/com/myfave/api/domain/order/entity/OrderStatus.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/entity/OrderStatus.java
@@ -1,5 +1,11 @@
 package com.myfave.api.domain.order.entity;
 
 public enum OrderStatus {
-    PENDING, PAID, CANCELLED, REFUNDED
+    PENDING,            // 결제 대기 중
+    PAID,               // 결제 완료
+    SHIPPING,           // 배송 중
+    DELIVERY_COMPLETED, // 배송 완료
+    PURCHASE_CONFIRMED, // 구매 확정
+    CANCELLED,          // 주문 취소
+    REFUNDED            // 환불 완료
 }

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -3,12 +3,14 @@ package com.myfave.api.domain.order.service;
 import com.myfave.api.domain.cart.entity.CartItem;
 import com.myfave.api.domain.cart.repository.CartItemRepository;
 import com.myfave.api.domain.order.dto.request.OrderCreateRequest;
+import com.myfave.api.domain.order.dto.response.OrderConfirmResponse;
 import com.myfave.api.domain.order.dto.response.OrderDetailResponse;
 import com.myfave.api.domain.order.dto.response.OrderListResponse;
 import com.myfave.api.domain.order.dto.response.OrderResponse;
 import com.myfave.api.domain.order.dto.response.OrderSummaryResponse;
 import com.myfave.api.domain.order.entity.Order;
 import com.myfave.api.domain.order.entity.OrderItem;
+import com.myfave.api.domain.order.entity.OrderStatus;
 import com.myfave.api.domain.order.entity.OrderType;
 import com.myfave.api.domain.order.repository.OrderItemRepository;
 import com.myfave.api.domain.order.repository.OrderRepository;
@@ -272,5 +274,46 @@ public class OrderService {
 
         // ── 7. OrderDetailResponse 반환 ───────────────────────────────────
         return OrderDetailResponse.from(order, payment, delivery, orderItems);
+    }
+
+    /**
+     * 주문 상태 변경 - 구매확정 (5-4)
+     * @Transactional: orderStatus를 PURCHASE_CONFIRMED로 변경하므로 쓰기 트랜잭션 적용
+     */
+    @Transactional
+    public OrderConfirmResponse confirmOrder(Long userId, Long orderId) {
+
+        // ── 1. userId null 체크 ──────────────────────────────────────────
+        // TODO: Auth API 완성 후 null 체크를 AUTH_UNAUTHORIZED 예외로 교체
+        if (userId == null) {
+            userId = 1L;
+        }
+
+        // ── 2. orderId → Order 조회 ──────────────────────────────────────
+        // 없으면 CustomException → GlobalExceptionHandler가 404 응답 반환
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        // ── 3. 본인 주문 확인 ────────────────────────────────────────────
+        // 로그인한 사람(userId)과 주문자(order.getUser())가 같아야 함
+        if (!order.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        // ── 4. 구매확정 가능 상태 확인 ───────────────────────────────────
+        // 스펙: DELIVERY_COMPLETED 상태인 주문만 구매확정 가능
+        // 그 외 상태(PENDING, PAID, SHIPPING 등)이면 409 반환
+        if (order.getOrderStatus() != OrderStatus.DELIVERY_COMPLETED) {
+            throw new CustomException(ErrorCode.ORDER_INVALID_STATUS);
+        }
+
+        // ── 5. 구매확정 처리 ─────────────────────────────────────────────
+        // order.confirm(): orderStatus를 PURCHASE_CONFIRMED로 변경
+        // @Transactional이므로 메서드 종료 시 JPA가 변경 감지 → UPDATE 쿼리 자동 실행
+        order.confirm();
+
+        // ── 6. 응답 반환 ─────────────────────────────────────────────────
+        // OrderConfirmResponse.from(order): orderId, orderStatus(PURCHASE_CONFIRMED) 반환
+        return OrderConfirmResponse.from(order);
     }
 }

--- a/backend/src/main/java/com/myfave/api/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/myfave/api/global/config/DataInitializer.java
@@ -176,5 +176,68 @@ public class DataInitializer implements CommandLineRunner {
         log.info("[DataInitializer] 테스트 배송 생성 완료 (id={})", delivery.getDeliveryId());
 
         log.info("[DataInitializer] 5-3 테스트 데이터 삽입 완료 — orderId={} 로 상세 조회 테스트 가능", order.getOrderId());
+
+        // ── 5-4 테스트용 Order 생성 (DELIVERY_COMPLETED 상태) ────────────
+        createConfirmTestData(user, product);
+    }
+
+    // 5-4 구매확정 테스트용 데이터 생성
+    // DELIVERY_COMPLETED 상태의 주문 → PATCH /orders/{orderId}/confirm 테스트에 사용
+    private void createConfirmTestData(User user, Product product) {
+
+        if (orderRepository.findByOrderNumber("ORD-20260407-TEST002").isPresent()) {
+            log.info("[DataInitializer] 5-4 테스트 데이터가 이미 존재합니다. 건너뜁니다.");
+            return;
+        }
+
+        // ── 6-1. Order 생성 ─────────────────────────────────────────
+        Order order = Order.builder()
+                .user(user)
+                .orderNumber("ORD-20260407-TEST002")
+                .orderType(OrderType.DIRECT)
+                .build();
+        orderRepository.save(order);
+
+        // ── 6-2. OrderItem 생성 ──────────────────────────────────────
+        OrderItem orderItem = OrderItem.builder()
+                .order(order)
+                .product(product)
+                .price(product.getPrice())
+                .productName(product.getProductName())
+                .build();
+        orderItemRepository.save(orderItem);
+
+        // ── 6-3. Payment 생성 + Order에 연결 ────────────────────────
+        Payment payment = Payment.builder()
+                .order(order)
+                .paymentMethod(PaymentMethod.CREDITCARD)
+                .totalProductPrice(10000)
+                .deliveryFee(3000)
+                .discountPrice(0)
+                .totalPaymentPrice(13000)
+                .build();
+        paymentRepository.save(payment);
+        order.completePay(payment); // orderStatus = PAID
+        orderRepository.save(order);
+
+        // ── 6-4. Delivery 생성 + 배송완료 처리 ──────────────────────
+        Delivery delivery = Delivery.builder()
+                .order(order)
+                .receiverName("홍길동")
+                .receiverPhone("010-1234-5678")
+                .receiverAddress("서울시 강남구 역삼동 123")
+                .deliveryRequest("문 앞에 놓아주세요")
+                .build();
+        deliveryRepository.save(delivery);
+        delivery.ship("CJ대한통운", "9876543210");
+        delivery.deliver(); // deliveryStatus = DELIVERED
+        deliveryRepository.save(delivery);
+
+        // ── 6-5. Order 상태 DELIVERY_COMPLETED로 변경 ───────────────
+        // completeDelivery(): orderStatus = DELIVERY_COMPLETED
+        order.completeDelivery();
+        orderRepository.save(order);
+
+        log.info("[DataInitializer] 5-4 테스트 데이터 삽입 완료 — orderId={} 로 구매확정 테스트 가능", order.getOrderId());
     }
 }


### PR DESCRIPTION
 📌 관련 이슈         

  Closes #35                                                                                          
   
  📝 작업 내용                                                                                        
                  
  주문 상태 변경(구매확정) API를 구현했습니다. DELIVERY_COMPLETED 상태의 주문을 PURCHASE_CONFIRMED로  
  변경합니다.
                                                                                                      
  🔍 변경 사항    

  - 기능 추가

  💡 구현 방법 / 주요 변경 포인트

  1. OrderStatus enum 확장                                                                            
  - SHIPPING, DELIVERY_COMPLETED, PURCHASE_CONFIRMED 3개 상태 추가
  - EnumType.STRING 사용 중이므로 DB 마이그레이션 불필요                                              
                                                        
  2. 상태 전이 메서드 추가 (Order.java)                                                               
  - completeDelivery() → DELIVERY_COMPLETED 설정                                                      
  - confirm() → PURCHASE_CONFIRMED 설정                                                               
                                                                                                      
  3. 구매확정 조건 검증                                                                               
  - DELIVERY_COMPLETED 상태가 아닌 주문은 ORDER_INVALID_STATUS(409) 반환
  - 본인 주문이 아니면 AUTH_FORBIDDEN(403) 반환                                                       
                                               
  4. DataInitializer 테스트 데이터 추가                                                               
  - ORD-20260407-TEST002: DELIVERY_COMPLETED 상태의 주문 (Swagger 테스트용)                           
                                                                                                      
  ✅ 테스트 방법                                                                                       
                                                                                                      
  1. 환경 설정: docker-compose up -d (DB 초기화 필요 시 docker-compose down -v)                       
  2. 실행 방법: ./gradlew bootRun → http://localhost:8080/api/v1/swagger-ui/index.html 접속
  3. 확인 사항:                                                                                       
    - PATCH /api/v1/orders/{orderId}/confirm — DELIVERY_COMPLETED 상태 주문 orderId 입력 → 200 OK,
  orderStatus: "PURCHASE_CONFIRMED" 반환 확인                                                         
    - 동일 orderId 재호출 → 409 ORDER_INVALID_STATUS 반환 확인
    - 다른 사용자 주문 orderId 입력 → 403 AUTH_FORBIDDEN 반환 확인                                    
    - 존재하지 않는 orderId 입력 → 404 ORDER_NOT_FOUND 반환 확인
                                                                                                      
  📸 스크린샷 (선택)
                                                                                                      
  해당 없음       

  ⚠️ 리뷰어에게 전달 사항                                                                             
   
  - 현재 JWT 인증 미완성으로 userId == null이면 1L로 fallback 처리 중. Auth API 완성 후               
  AUTH_UNAUTHORIZED 예외로 교체 예정
  - DELIVERY_COMPLETED 상태로의 전이는 배송 관련 API 구현 시 연동 예정                                
                                                                                                      
  📋 셀프 체크리스트
                                                                                                      

- [ ] 코드 컨벤션을 준수했나요?                                                                         
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?                                                                     
- [ ] PR 제목이 명확한가요? (예: [FEAT] 5-4 주문 상태 변경(구매확정) API 구현)   
