### PR TITLE
feat: 상품 soft delete 및 품절 처리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ Talk with AI/
 
 # 개인 문서
 Sprint_계획서.md
-.claude\settings.local.json
+.claude/
+meetings/

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -75,4 +75,22 @@ public class ProductController {
         Long updatedId = productService.updateProduct(userId, productId, request, images);
         return ResponseEntity.ok(ApiResponse.ok(Map.of("id", updatedId)));
     }
+
+    // 3-5. 상품 삭제 (인플루언서 전용, Soft Delete)
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> deleteProduct(@PathVariable Long productId) {
+        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
+        Long userId = 1L;
+        productService.deleteProduct(userId, productId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    // 3-6. 품절 처리 (인플루언서 전용)
+    @PatchMapping("/{productId}/soldout")
+    public ResponseEntity<ApiResponse<Void>> markAsSoldout(@PathVariable Long productId) {
+        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
+        Long userId = 1L;
+        productService.markAsSoldout(userId, productId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -88,7 +88,7 @@ public class Product extends BaseEntity {
     public void softDelete() {
         this.deletedAt = ZonedDateTime.now();
     }
-    //order 도메인에서 삭제 여부 확인 처리하는 용도
+    //order 도메인에서 삭제 여부 확인 처리하는 용도 (OrderService에 삭제된 상품 주문 불가 검증)
     public boolean isDeleted() {
         return this.deletedAt != null;
     }

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -88,7 +88,7 @@ public class Product extends BaseEntity {
     public void softDelete() {
         this.deletedAt = ZonedDateTime.now();
     }
-
+    //order 도메인에서 삭제 여부 확인 처리하는 용도
     public boolean isDeleted() {
         return this.deletedAt != null;
     }

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -13,6 +13,7 @@ import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.global.util.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -24,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +34,7 @@ public class ProductService {
     private final ProductRepository productRepository; //상품 데이터
     private final ProductImageRepository productImageRepository; //이미지 데이터
     private final UserRepository userRepository;
+    private final S3UploadService s3UploadService;
 
     //설정파일에서 읽어오는거라 인플루언서 아이디 application.yml 에서 변경 가능
     @Value("${influencer.user-id}")
@@ -97,8 +98,7 @@ public class ProductService {
         // 이미지 저장 (첫 번째 이미지가 메인)
         for (int i = 0; i < images.size(); i++) {
             MultipartFile image = images.get(i);
-            // TODO: Sprint 2에서 S3 업로드로 교체
-            String imageUrl = "/images/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+            String imageUrl = s3UploadService.upload(image, "products");
 
             ProductImage productImage = ProductImage.builder()
                     .product(product)
@@ -151,8 +151,7 @@ public class ProductService {
 
             for (int i = 0; i < newImages.size(); i++) {
                 MultipartFile image = newImages.get(i);
-                // TODO: Sprint 2에서 S3 업로드로 교체
-                String imageUrl = "/images/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
+                String imageUrl = s3UploadService.upload(image, "products");
 
                 ProductImage productImage = ProductImage.builder()
                         .product(product)

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -167,6 +167,29 @@ public class ProductService {
         return product.getProductId();
     }
 
+    // 3-5. 상품 삭제 (인플루언서 전용, Soft Delete)
+    @Transactional
+    public void deleteProduct(Long userId, Long productId) {
+        validateInfluencer(userId); //인플루언서 검증
+
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                //값이 없으면 예외처리, 있으면 값 꺼내서 soft delete
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.softDelete(); //deletedAt에 현재 시각 세팅
+    }
+
+    // 3-6. 품절 처리 (인플루언서 전용)
+    @Transactional
+    public void markAsSoldout(Long userId, Long productId) {
+        validateInfluencer(userId);
+
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_SOLD_OUT));
+
+        product.markAsSoldout(); //isSoldout = true로 변경
+    }
+
     // 인플루언서 권한 검증
     private void validateInfluencer(Long userId) {
         if (!influencerUserId.equals(userId)) {

--- a/backend/src/main/java/com/myfave/api/global/config/S3Config.java
+++ b/backend/src/main/java/com/myfave/api/global/config/S3Config.java
@@ -1,13 +1,37 @@
 package com.myfave.api.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class S3Config {
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    //AWS S3랑 통신하는 client, 컨테이너에 등록
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
 
     public String getBucket() {
         return bucket;

--- a/backend/src/main/java/com/myfave/api/global/util/S3UploadService.java
+++ b/backend/src/main/java/com/myfave/api/global/util/S3UploadService.java
@@ -1,0 +1,94 @@
+package com.myfave.api.global.util;
+
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3UploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    private static final List<String> IMAGE_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
+    private static final List<String> GIF_EXTENSIONS = List.of("gif");
+    private static final List<String> VIDEO_EXTENSIONS = List.of("mp4", "mov", "avi");
+    //파일 크기 제한
+    private static final long IMAGE_MAX_SIZE = 10 * 1024 * 1024;   // 10MB
+    private static final long VIDEO_MAX_SIZE = 100 * 1024 * 1024;  // 100MB
+
+    /**
+     * S3에 파일 업로드 후 URL 반환
+     *
+     * @param file      업로드할 파일
+     * @param directory S3 버킷 내 경로 (예: "products", "contents/shortforms")
+     * @return 업로드된 파일의 S3 URL
+     */
+    public String upload(MultipartFile file, String directory) {
+        // step1. 검증 (확장자, 파일타입, 파일크기)
+        String extension = extractExtension(file.getOriginalFilename());
+        validateFileType(extension);
+        validateFileSize(file.getSize(), extension);
+        //step2. S3 업로드
+        String key = directory + "/" + UUID.randomUUID() + "." + extension;
+
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putRequest, RequestBody.fromBytes(file.getBytes()));
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+        //step3. URL 반환
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new CustomException(ErrorCode.FILE_INVALID_TYPE);
+        }
+        return filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private void validateFileType(String extension) {
+        boolean allowed = IMAGE_EXTENSIONS.contains(extension)
+                || GIF_EXTENSIONS.contains(extension)
+                || VIDEO_EXTENSIONS.contains(extension);
+
+        if (!allowed) {
+            throw new CustomException(ErrorCode.FILE_INVALID_TYPE);
+        }
+    }
+
+    private void validateFileSize(long size, String extension) {
+        if (VIDEO_EXTENSIONS.contains(extension)) {
+            if (size > VIDEO_MAX_SIZE) {
+                throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+            }
+        } else {
+            if (size > IMAGE_MAX_SIZE) {
+                throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #51

## 📝 작업 내용
  상품 Soft Delete 및 품절 처리 API 구현                                                                                                                               

## 💡 구현 방법 / 주요 변경 포인트
  - `DELETE /products/{productId}` — softDelete() 호출로 deletedAt에 현재 시각 세팅, 이후 목록/상세 조회에서 자동 필터링                                               
  - `PATCH /products/{productId}/soldout` — markAsSoldout() 호출로 isSoldout = true 변경, 품절 상품은 조회는 되되 주문 불가                                            
  - 두 API 모두 인플루언서 권한 검증 포함                                                                                                                              
  - 기존 Repository 쿼리(`findByDeletedAtIsNull`)를 활용하여 삭제된 상품 재삭제 방지 
## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
  1. Swagger(`/api/v1/swagger-ui/index.html`)에서 테스트                                                                                                               
  2. `DELETE /products/{productId}` 호출 후 `GET /products`에서 해당 상품 미노출 확인                                                                                  
  3. `PATCH /products/{productId}/soldout` 호출 후 `GET /products`에서 `isSoldOut: true` 확인                                                                          
  4. 삭제된 상품 ID로 상세 조회 시 404 반환 확인


## ⚠️ 리뷰어에게 전달 사항
**OrderService에 삭제된 상품 주문 불가 검증이 아직 없음** — 현재 `findById`로 조회하기 때문에 삭제된 상품도 주문 가능한 상태
-> Order 쪽에 `product.isDeleted()` 체크 추가 필요 (DIRECT, CART 주문 모두)  
### order 도메인 건들면 conflict 날까봐 빼고 진행함 !! order 도메인 더 수정할 거 없을 때 말해주면 반영하겠음!                                                                                                 
