### PR TITLE
feat: 배송지 삭제 API 구현 (#52)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
@@ -35,7 +35,7 @@ public class ShippingController {
             @PathVariable Long addressId) {
         Long userId = 1L;
         shippingService.deleteShippingAddress(userId, addressId);
-        return ResponseEntity.ok(new ApiResponse<>(200, "배송지가 삭제되었습니다.", null));
+        return ResponseEntity.ok(ApiResponse.ok("배송지가 삭제되었습니다."));
     }
 }
 

--- a/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
@@ -10,6 +10,9 @@ import com.myfave.api.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
 import java.util.List;
 
 @RestController
@@ -24,6 +27,15 @@ public class ShippingController {
         Long userId = 1L; //임시 하드코딩
         List<ShippingAddressResponse> response = shippingService.getShippingAddresses(userId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 7-3. 배송지 삭제
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<Void>> deleteShippingAddress(
+            @PathVariable Long addressId) {
+        Long userId = 1L;
+        shippingService.deleteShippingAddress(userId, addressId);
+        return ResponseEntity.ok(new ApiResponse<>(200, "배송지가 삭제되었습니다.", null));
     }
 }
 

--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -33,4 +33,20 @@ public class ShippingService {
                 .map(ShippingAddressResponse::from)
                 .toList();
     }
+
+    // 7-3. 배송지 삭제
+    @Transactional
+    public void deleteShippingAddress(Long userId, Long addressId) {
+        // 1) 배송지가 존재하는지 확인
+        ShippingAddress shippingAddress = shippingAddressRepository.findById(addressId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND));
+
+        // 2) 본인 배송지인지 확인
+        if (!shippingAddress.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        // 3) db에서 삭제
+        shippingAddressRepository.delete(shippingAddress);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #52

## 📝 작업 내용
- DELETE /shipping/{addressId}: 배송지 삭제 (Hard Delete)
- ShippingController에 deleteShippingAddress 엔드포인트 추가
- ShippingService에 deleteShippingAddress 메서드 구현
- 본인 배송지 확인 (AUTH_FORBIDDEN)
- 존재하지 않는 배송지 처리 (SHIPPING_ADDRESS_NOT_FOUND)
- 
## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)
