### PR TITLE
feat: 기본 배송지 설정 API 구현 (#58)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
@@ -20,6 +20,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
+import com.myfave.api.domain.shipping.dto.response.DefaultAddressResponse;
+import org.springframework.web.bind.annotation.PatchMapping;
+
 @RestController
 @RequestMapping("/shipping")
 @RequiredArgsConstructor
@@ -51,5 +54,14 @@ public class ShippingController {
         Long userId = 1L;
         shippingService.deleteShippingAddress(userId, addressId);
         return ResponseEntity.ok(ApiResponse.ok("배송지가 삭제되었습니다."));
+    }
+
+    // 7-4. 기본 배송지 설정
+    @PatchMapping("/{addressId}/default")
+    public ResponseEntity<ApiResponse<DefaultAddressResponse>> setDefaultAddress(
+            @PathVariable Long addressId) {
+        Long userId = 1L;
+        DefaultAddressResponse response = shippingService.setDefaultAddress(userId, addressId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/shipping/dto/response/DefaultAddressResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/dto/response/DefaultAddressResponse.java
@@ -1,0 +1,20 @@
+package com.myfave.api.domain.shipping.dto.response;
+
+import com.myfave.api.domain.shipping.entity.ShippingAddress;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DefaultAddressResponse {
+
+    private Long shippingId;
+    private Boolean isDefault;
+
+    public static DefaultAddressResponse from(ShippingAddress shippingAddress) {
+        return new DefaultAddressResponse(
+                shippingAddress.getShippingId(),
+                shippingAddress.getIsDefault()
+        );
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -16,6 +16,8 @@ import com.myfave.api.domain.shipping.dto.request.ShippingAddressRequest;
 
 import java.util.List;
 
+import com.myfave.api.domain.shipping.dto.response.DefaultAddressResponse;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -70,5 +72,27 @@ public class ShippingService {
 
         // 3) db에서 삭제
         shippingAddressRepository.delete(shippingAddress);
+    }
+
+    // 7-4. 기본 배송지 설정
+    @Transactional
+    public DefaultAddressResponse setDefaultAddress(Long userId, Long addressId) {
+        ShippingAddress shippingAddress = shippingAddressRepository.findById(addressId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SHIPPING_ADDRESS_NOT_FOUND));
+
+        if (!shippingAddress.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        User user = shippingAddress.getUser();
+
+        // 기존 기본 배송지 해제
+        shippingAddressRepository.findByUserAndIsDefaultTrue(user)
+                .ifPresent(existing -> existing.unsetDefault());
+
+        // 새 기본 배송지 설정
+        shippingAddress.setAsDefault();
+
+        return DefaultAddressResponse.from(shippingAddress);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #58 

## 📝 작업 내용
- PATCH /shipping/{addressId}/default: 기본 배송지 설정
- ShippingController에 setDefaultAddress 엔드포인트 추가
- ShippingService에 setDefaultAddress 메서드 구현
- DefaultAddressResponse DTO 생성 (명세서 응답 형식에 맞춤)
- 기존 기본 배송지 해제 후 새 기본 배송지 설정

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
명세서 응답 메시지가 "기본 배송지로 설정되었습니다."인데,
팩토리 메서드(ApiResponse.ok())를 사용해서 메시지가 지금 "OK"로 나오는 상황이야

현재: {"code": 200, "message": "OK", "data": {...}}
명세서: {"code": 200, "message": "기본 배송지로 설정되었습니다.", "data": {...}}

팩토리 메서드 사용을 우선했는데, 명세서 메시지를 살려야 하면 수정할게!
return ResponseEntity.ok(new ApiResponse<>(200, "기본 배송지로 설정되었습니다.", response)); 이런식으로!


## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)
