### PR TITLE
fix: 배송지 추가 시 isDefault 항상 false로 저장

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/dto/request/ShippingAddressRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/dto/request/ShippingAddressRequest.java
@@ -28,10 +28,4 @@ public class ShippingAddressRequest {
 
     @Size(max = 100, message = "배송 요청사항은 100자 이내여야 합니다.")
     private String deliveryRequest;
-
-    private Boolean isDefault;
-
-    public Boolean getIsDefault() {
-        return isDefault != null ? isDefault : false;
-    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -49,7 +49,7 @@ public class ShippingService {
                 .addressDetail(request.getAddressDetail())
                 .zipCode(request.getZipCode())
                 .deliveryRequest(request.getDeliveryRequest())
-                .isDefault(request.getIsDefault())
+                .isDefault(false)
                 .build();
 
         shippingAddressRepository.save(shippingAddress);


### PR DESCRIPTION
## 📌 관련 이슈
Closes #46 

## 📝 작업 내용
- ShippingAddressRequest에서 isDefault 필드 및 getIsDefault() 제거
- ShippingService에서 .isDefault(false)로 고정
- 기본 배송지 설정은 7-4 (PATCH /shipping/{id}/default)에서만 처리
## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)
