### PR TITLE
[feat] 보유쿠폰목록조회 8-1

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/coupon/controller/CouponController.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/controller/CouponController.java
@@ -1,9 +1,17 @@
 package com.myfave.api.domain.coupon.controller;
 
+import com.myfave.api.domain.coupon.dto.response.CouponResponse;
+import com.myfave.api.domain.coupon.entity.CouponStatus;
 import com.myfave.api.domain.coupon.service.CouponService;
+import com.myfave.api.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/coupons")
@@ -11,4 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
     private final CouponService couponService;
+
+    // 8-1. 보유 쿠폰 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CouponResponse>>> getMyCoupons(
+            @RequestParam(required = false) CouponStatus status) {
+        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
+        Long userId = 1L;
+        List<CouponResponse> response = couponService.getMyCoupons(userId, status);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/dto/response/CouponResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/dto/response/CouponResponse.java
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 public class CouponResponse {
 
-    private Long id;
+    private Long couponId;
     private String couponName;
     private CouponType couponType;
     private Integer discountPrice;

--- a/backend/src/main/java/com/myfave/api/domain/coupon/dto/response/CouponResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/dto/response/CouponResponse.java
@@ -2,6 +2,7 @@ package com.myfave.api.domain.coupon.dto.response;
 
 import com.myfave.api.domain.coupon.entity.Coupon;
 import com.myfave.api.domain.coupon.entity.CouponStatus;
+import com.myfave.api.domain.coupon.entity.CouponType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,19 +12,23 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 public class CouponResponse {
 
-    private Long couponId;
+    private Long id;
     private String couponName;
+    private CouponType couponType;
     private Integer discountPrice;
     private CouponStatus status;
     private ZonedDateTime expiredAt;
+    private ZonedDateTime createdAt;
 
     public static CouponResponse from(Coupon coupon) {
         return new CouponResponse(
                 coupon.getCouponId(),
                 coupon.getCouponMaster().getCouponName(),
+                coupon.getCouponMaster().getCouponType(),
                 coupon.getCouponMaster().getDiscountPrice(),
                 coupon.getStatus(),
-                coupon.getExpiredAt()
+                coupon.getExpiredAt(),
+                coupon.getCreatedAt()
         );
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
@@ -1,10 +1,19 @@
 package com.myfave.api.domain.coupon.service;
 
+import com.myfave.api.domain.coupon.dto.response.CouponResponse;
+import com.myfave.api.domain.coupon.entity.Coupon;
+import com.myfave.api.domain.coupon.entity.CouponStatus;
 import com.myfave.api.domain.coupon.repository.CouponMasterRepository;
 import com.myfave.api.domain.coupon.repository.CouponRepository;
+import com.myfave.api.domain.user.entity.User;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +22,19 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
     private final CouponMasterRepository couponMasterRepository;
+    private final UserRepository userRepository;
+
+    // 8-1. 보유 쿠폰 목록 조회
+    public List<CouponResponse> getMyCoupons(Long userId, CouponStatus status) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Coupon> coupons = (status == null)
+                ? couponRepository.findByUser(user)
+                : couponRepository.findByUserAndStatus(user, status);
+
+        return coupons.stream()
+                .map(CouponResponse::from)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #64 

## 📝 작업 내용
사용자가 보유한 쿠폰 목록을 조회하는 API(GET /coupons)를 구현
쿠폰 상태(AVAILABLE/USED/EXPIRED)로 필터링할 수 있으며, 필터 미전달 시 전체 쿠폰을 반환

## 💡 구현 방법 / 주요 변경 포인트
 - CouponController: GET /coupons 엔드포인트 추가, status 쿼리 파라미터를 CouponStatus enum으로 받도록 구현 (required = false로 옵셔널 처리)                          
  - CouponService.getMyCoupons(userId, status): status가 null이면 findByUser로 전체 조회, 값이 있으면 findByUserAndStatus로 필터링


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 사용자의 보유 중인 쿠폰 목록을 조회할 수 있는 새로운 API 엔드포인트 추가
* 쿠폰을 상태(유효, 만료 등)에 따라 필터링하여 조회 가능한 선택적 필터링 기능 추가
* 쿠폰 조회 시 각 쿠폰의 생성 날짜 정보 포함
* 쿠폰 조회 시 각 쿠폰의 유형 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->