### PR TITLE
feat: 숏폼 목록 조회 API 

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
@@ -5,10 +5,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.myfave.api.domain.content.dto.response.ShortFormResponse;
+import com.myfave.api.domain.content.entity.ShortFormType;
+import com.myfave.api.global.common.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
 @RestController
 @RequestMapping("/content")
 @RequiredArgsConstructor
 public class ContentController {
 
     private final ContentService contentService;
+
+    // 9-1. 숏폼 목록 조회
+    @GetMapping("/short-forms")
+    public ResponseEntity<ApiResponse<List<ShortFormResponse>>> getShortForms(
+            @RequestParam(required = false) ShortFormType type,
+            @RequestParam(defaultValue = "10") int size) {
+        List<ShortFormResponse> response = contentService.getShortForms(type, size);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
@@ -11,12 +11,15 @@ import com.myfave.api.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import jakarta.validation.constraints.Min;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/content")
 @RequiredArgsConstructor
+@Validated
 public class ContentController {
 
     private final ContentService contentService;
@@ -25,7 +28,7 @@ public class ContentController {
     @GetMapping("/short-forms")
     public ResponseEntity<ApiResponse<List<ShortFormResponse>>> getShortForms(
             @RequestParam(required = false) ShortFormType type,
-            @RequestParam(defaultValue = "10") int size) {
+            @Min(1) @RequestParam(defaultValue = "10") int size) {
         List<ShortFormResponse> response = contentService.getShortForms(type, size);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/backend/src/main/java/com/myfave/api/domain/content/dto/response/ShortFormResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/dto/response/ShortFormResponse.java
@@ -5,23 +5,28 @@ import com.myfave.api.domain.content.entity.ShortFormType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+
 @Getter
 @AllArgsConstructor
 public class ShortFormResponse {
 
     private Long shortFormId;
-    private Long productId;
+    private ShortFormType displayType;
     private String videoUrl;
     private String thumbnailUrl;
-    private ShortFormType displayType;
+    private Long productId;
+    private String productName;
+    private Integer price;
 
     public static ShortFormResponse from(ShortForm shortForm) {
         return new ShortFormResponse(
                 shortForm.getShortFormId(),
-                shortForm.getProduct() != null ? shortForm.getProduct().getProductId() : null,
+                shortForm.getDisplayType(),
                 shortForm.getVideoUrl(),
                 shortForm.getThumbnailUrl(),
-                shortForm.getDisplayType()
+                shortForm.getProduct() != null ? shortForm.getProduct().getProductId() : null,
+                shortForm.getProduct() != null ? shortForm.getProduct().getProductName() : null,
+                shortForm.getProduct() != null ? shortForm.getProduct().getPrice() : null
         );
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
@@ -3,6 +3,8 @@ package com.myfave.api.domain.content.repository;
 import com.myfave.api.domain.content.entity.ShortForm;
 import com.myfave.api.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import com.myfave.api.domain.content.entity.ShortFormType;
+
 
 import java.util.List;
 
@@ -10,4 +12,6 @@ public interface ShortFormRepository extends JpaRepository<ShortForm, Long> {
 
     // 상품과 연결된 숏폼 목록
     List<ShortForm> findByProduct(Product product);
+    List<ShortForm> findByDisplayType(ShortFormType displayType);
+
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
@@ -4,6 +4,8 @@ import com.myfave.api.domain.content.entity.ShortForm;
 import com.myfave.api.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.myfave.api.domain.content.entity.ShortFormType;
+import org.springframework.data.domain.Pageable;
+
 
 
 import java.util.List;
@@ -12,6 +14,6 @@ public interface ShortFormRepository extends JpaRepository<ShortForm, Long> {
 
     // 상품과 연결된 숏폼 목록
     List<ShortForm> findByProduct(Product product);
-    List<ShortForm> findByDisplayType(ShortFormType displayType);
+    List<ShortForm> findByDisplayType(ShortFormType displayType, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -5,6 +5,9 @@ import com.myfave.api.domain.content.repository.StyleFeedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import com.myfave.api.domain.content.dto.response.ShortFormResponse;
 import com.myfave.api.domain.content.entity.ShortFormType;
@@ -21,21 +24,20 @@ public class ContentService {
 
     // 9-1. 숏폼 목록 조회
     public List<ShortFormResponse> getShortForms(ShortFormType type, int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "shortFormId"));
+
         List<ShortFormResponse> shortForms;
 
         if (type != null) {
-            shortForms = shortFormRepository.findByDisplayType(type).stream()
+            shortForms = shortFormRepository.findByDisplayType(type, pageable).stream()
                     .map(ShortFormResponse::from)
                     .toList();
         } else {
-            shortForms = shortFormRepository.findAll().stream()
+            shortForms = shortFormRepository.findAll(pageable).getContent().stream()
                     .map(ShortFormResponse::from)
                     .toList();
         }
 
-        if (shortForms.size() > size) {
-            return shortForms.subList(0, size);
-        }
         return shortForms;
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -6,6 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.myfave.api.domain.content.dto.response.ShortFormResponse;
+import com.myfave.api.domain.content.entity.ShortFormType;
+
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -13,4 +18,24 @@ public class ContentService {
 
     private final ShortFormRepository shortFormRepository;
     private final StyleFeedRepository styleFeedRepository;
+
+    // 9-1. 숏폼 목록 조회
+    public List<ShortFormResponse> getShortForms(ShortFormType type, int size) {
+        List<ShortFormResponse> shortForms;
+
+        if (type != null) {
+            shortForms = shortFormRepository.findByDisplayType(type).stream()
+                    .map(ShortFormResponse::from)
+                    .toList();
+        } else {
+            shortForms = shortFormRepository.findAll().stream()
+                    .map(ShortFormResponse::from)
+                    .toList();
+        }
+
+        if (shortForms.size() > size) {
+            return shortForms.subList(0, size);
+        }
+        return shortForms;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #77

## 📝 작업 내용
- GET /content/short-forms: 숏폼 목록 조회
- Query Parameters: type(숏폼 타입 필터), size(조회 개수, 기본값 10)"


## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
명세서 상 /contents 인데 현재 우리 코드가 /content로 만들어져있어서 일단 그대로 진행함

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 숏폼 콘텐츠 조회용 새로운 GET 엔드포인트 추가
  * 유형(필터) 선택과 조회 수(size) 지정으로 결과 제어 가능(기본값 제공)
  * 페이지네이션 기반 상위 항목 우선 반환으로 최신 항목 우선 표시
  * 숏폼 응답에 상품명과 가격 정보가 포함되어 더 상세한 데이터 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->