### PR TITLE
Feat: 쿠폰 사용 복구&만료 처리

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/coupon/entity/Coupon.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/entity/Coupon.java
@@ -48,6 +48,10 @@ public class Coupon extends BaseEntity {
         this.status = CouponStatus.USED;
     }
 
+    public void restore() {
+        this.status = CouponStatus.AVAILABLE;
+    }
+
     public void expire() {
         this.status = CouponStatus.EXPIRED;
     }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/repository/CouponRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/repository/CouponRepository.java
@@ -4,7 +4,11 @@ import com.myfave.api.domain.coupon.entity.Coupon;
 import com.myfave.api.domain.coupon.entity.CouponStatus;
 import com.myfave.api.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
@@ -14,4 +18,14 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     // 사용 가능한 쿠폰만
     List<Coupon> findByUserAndStatus(User user, CouponStatus status);
+
+    // Lazy 만료 전환: 해당 사용자의 AVAILABLE 쿠폰 중 만료된 것을 EXPIRED로 일괄 전환
+    // 벌크 UPDATE는 @LastModifiedDate 리스너가 동작하지 않으므로 updatedAt을 명시적으로 갱신
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Coupon c SET c.status = com.myfave.api.domain.coupon.entity.CouponStatus.EXPIRED, " +
+            "c.updatedAt = :now " +
+            "WHERE c.user = :user " +
+            "AND c.status = com.myfave.api.domain.coupon.entity.CouponStatus.AVAILABLE " +
+            "AND c.expiredAt < :now")
+    int expireAvailableCouponsBefore(@Param("user") User user, @Param("now") ZonedDateTime now);
 }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
@@ -13,6 +13,7 @@ import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -101,6 +103,30 @@ public class CouponService {
             case USED -> throw new CustomException(ErrorCode.COUPON_ALREADY_USED);
             case EXPIRED -> throw new CustomException(ErrorCode.COUPON_EXPIRED);
             case AVAILABLE -> coupon.use();
+        }
+    }
+
+    // 8-3. 쿠폰 복구 (주문 취소/환불 트랜잭션 내에서 호출)
+    // USED 상태가 아닌 경우 no-op (재시도 안전성)
+    @Transactional
+    public void restoreCoupon(Long couponId, Long userId) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (!coupon.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        if (coupon.getStatus() != CouponStatus.USED) {
+            log.warn("restoreCoupon called on non-USED coupon: couponId={}, status={}",
+                    couponId, coupon.getStatus());
+            return;
+        }
+
+        if (coupon.getExpiredAt().isBefore(ZonedDateTime.now())) {
+            coupon.expire();
+        } else {
+            coupon.restore();
         }
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
@@ -79,4 +79,28 @@ public class CouponService {
 
         return CouponIssueResponse.from(coupon);
     }
+
+    // 8-3. 쿠폰 사용 (Payment/Order 도메인 트랜잭션 내에서 호출)
+    @Transactional
+    public void useCoupon(Long couponId, Long userId) {
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (!coupon.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        // Lazy 만료 처리: AVAILABLE이지만 만료 지난 경우 EXPIRED 예외만 던지고 상태 전환은 다음 조회 시 벌크 쿼리가 담당
+        // (여기서 expire() 호출 후 throw 하면 트랜잭션 롤백으로 변경이 손실됨)
+        if (coupon.getStatus() == CouponStatus.AVAILABLE
+                && coupon.getExpiredAt().isBefore(ZonedDateTime.now())) {
+            throw new CustomException(ErrorCode.COUPON_EXPIRED);
+        }
+
+        switch (coupon.getStatus()) {
+            case USED -> throw new CustomException(ErrorCode.COUPON_ALREADY_USED);
+            case EXPIRED -> throw new CustomException(ErrorCode.COUPON_EXPIRED);
+            case AVAILABLE -> coupon.use();
+        }
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/service/CouponService.java
@@ -37,9 +37,13 @@ public class CouponService {
     private Long influencerUserId;
 
     // 8-1. 보유 쿠폰 목록 조회
+    @Transactional
     public List<CouponResponse> getMyCoupons(Long userId, CouponStatus status) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // Lazy 만료 전환: 조회 전에 만료된 AVAILABLE 쿠폰을 EXPIRED로 일괄 처리
+        couponRepository.expireAvailableCouponsBefore(user, ZonedDateTime.now());
 
         List<Coupon> coupons = (status == null)
                 ? couponRepository.findByUser(user)

--- a/backend/src/test/java/com/myfave/api/domain/coupon/service/CouponServiceTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/coupon/service/CouponServiceTest.java
@@ -1,0 +1,243 @@
+package com.myfave.api.domain.coupon.service;
+
+import com.myfave.api.domain.coupon.entity.Coupon;
+import com.myfave.api.domain.coupon.entity.CouponStatus;
+import com.myfave.api.domain.coupon.repository.CouponMasterRepository;
+import com.myfave.api.domain.coupon.repository.CouponRepository;
+import com.myfave.api.domain.user.entity.User;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private CouponMasterRepository couponMasterRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    private static final Long COUPON_ID = 100L;
+    private static final Long OWNER_ID = 1L;
+    private static final Long OTHER_USER_ID = 2L;
+
+    private Coupon mockCoupon(CouponStatus status, ZonedDateTime expiredAt, Long ownerId) {
+        Coupon coupon = mock(Coupon.class);
+        User user = mock(User.class);
+        lenient().when(coupon.getUser()).thenReturn(user);
+        lenient().when(user.getUserId()).thenReturn(ownerId);
+        lenient().when(coupon.getStatus()).thenReturn(status);
+        lenient().when(coupon.getExpiredAt()).thenReturn(expiredAt);
+        return coupon;
+    }
+
+    // ================== useCoupon ==================
+
+    @Test
+    @DisplayName("useCoupon 성공 - AVAILABLE 쿠폰 사용 시 USED 전환")
+    void useCoupon_success() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.AVAILABLE, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when
+        couponService.useCoupon(COUPON_ID, OWNER_ID);
+
+        // then
+        verify(coupon).use();
+    }
+
+    @Test
+    @DisplayName("useCoupon 실패 - 존재하지 않는 쿠폰이면 COUPON_NOT_FOUND")
+    void useCoupon_notFound() {
+        // given
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> couponService.useCoupon(COUPON_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.COUPON_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("useCoupon 실패 - 소유자가 다르면 AUTH_FORBIDDEN")
+    void useCoupon_notOwner() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.AVAILABLE, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when & then
+        assertThatThrownBy(() -> couponService.useCoupon(COUPON_ID, OTHER_USER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_FORBIDDEN));
+        verify(coupon, never()).use();
+    }
+
+    @Test
+    @DisplayName("useCoupon 실패 - 이미 사용된 쿠폰이면 COUPON_ALREADY_USED")
+    void useCoupon_alreadyUsed() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.USED, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when & then
+        assertThatThrownBy(() -> couponService.useCoupon(COUPON_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.COUPON_ALREADY_USED));
+    }
+
+    @Test
+    @DisplayName("useCoupon 실패 - AVAILABLE이지만 만료 지나면 COUPON_EXPIRED (상태 전환은 다음 조회 시 벌크 쿼리가 담당)")
+    void useCoupon_lazyExpired() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.AVAILABLE, ZonedDateTime.now().minusDays(1), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when & then
+        assertThatThrownBy(() -> couponService.useCoupon(COUPON_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.COUPON_EXPIRED));
+        // expire() 호출 시 트랜잭션 롤백으로 변경이 손실되므로 호출하지 않음
+        verify(coupon, never()).expire();
+        verify(coupon, never()).use();
+    }
+
+    @Test
+    @DisplayName("useCoupon 실패 - EXPIRED 상태면 COUPON_EXPIRED")
+    void useCoupon_alreadyExpired() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.EXPIRED, ZonedDateTime.now().minusDays(1), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when & then
+        assertThatThrownBy(() -> couponService.useCoupon(COUPON_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.COUPON_EXPIRED));
+    }
+
+    // ================== restoreCoupon ==================
+
+    @Test
+    @DisplayName("restoreCoupon 성공 - USED + 만료 전이면 AVAILABLE로 복귀")
+    void restoreCoupon_success() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.USED, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when
+        couponService.restoreCoupon(COUPON_ID, OWNER_ID);
+
+        // then
+        verify(coupon).restore();
+        verify(coupon, never()).expire();
+    }
+
+    @Test
+    @DisplayName("restoreCoupon 성공 - USED + 만료 지났으면 EXPIRED로 전환")
+    void restoreCoupon_expiredInsteadOfRestore() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.USED, ZonedDateTime.now().minusDays(1), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when
+        couponService.restoreCoupon(COUPON_ID, OWNER_ID);
+
+        // then
+        verify(coupon).expire();
+        verify(coupon, never()).restore();
+    }
+
+    @Test
+    @DisplayName("restoreCoupon no-op - USED가 아닌 상태면 아무 동작 안 함 (재시도 안전성)")
+    void restoreCoupon_noOpForNonUsed() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.AVAILABLE, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when
+        couponService.restoreCoupon(COUPON_ID, OWNER_ID);
+
+        // then
+        verify(coupon, never()).restore();
+        verify(coupon, never()).expire();
+    }
+
+    @Test
+    @DisplayName("restoreCoupon 실패 - 소유자가 다르면 AUTH_FORBIDDEN")
+    void restoreCoupon_notOwner() {
+        // given
+        Coupon coupon = mockCoupon(CouponStatus.USED, ZonedDateTime.now().plusDays(3), OWNER_ID);
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.of(coupon));
+
+        // when & then
+        assertThatThrownBy(() -> couponService.restoreCoupon(COUPON_ID, OTHER_USER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_FORBIDDEN));
+        verify(coupon, never()).restore();
+        verify(coupon, never()).expire();
+    }
+
+    @Test
+    @DisplayName("restoreCoupon 실패 - 존재하지 않는 쿠폰이면 COUPON_NOT_FOUND")
+    void restoreCoupon_notFound() {
+        // given
+        given(couponRepository.findById(COUPON_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> couponService.restoreCoupon(COUPON_ID, OWNER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.COUPON_NOT_FOUND));
+    }
+
+    // ================== getMyCoupons ==================
+
+    @Test
+    @DisplayName("getMyCoupons - 조회 전 expireAvailableCouponsBefore 벌크 쿼리 호출")
+    void getMyCoupons_triggersLazyExpiration() {
+        // given
+        User user = mock(User.class);
+        given(userRepository.findById(OWNER_ID)).willReturn(Optional.of(user));
+        given(couponRepository.findByUser(user)).willReturn(List.of());
+
+        // when
+        couponService.getMyCoupons(OWNER_ID, null);
+
+        // then
+        verify(couponRepository).expireAvailableCouponsBefore(eq(user), any(ZonedDateTime.class));
+        verify(couponRepository).findByUser(user);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #68 

## 📝 작업 내용
Payment/Order 도메인 트랜잭션 내에서 호출할 쿠폰 사용/복구 내부 서비스 메서드를 추가하고, 보유 쿠폰 목록 조회(8-1)에 Lazy 만료 전환 로직 추가
  공개 REST API가 아닌 **내부 계약**으로, A팀원(Payment/Order)이 자기 도메인 트랜잭션 안에서 호출할 예정

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
### 1. `CouponService.useCoupon(couponId, userId)`                                                                                                                   
  - 쿠폰 조회 → 소유자 검증 → 상태/만료 검증 → USED 전환                                                                                                               
  - **Lazy 만료 처리**: AVAILABLE이지만 만료 시간이 지난 쿠폰은 `COUPON_EXPIRED` 예외만 던지고, 실제 EXPIRED 상태 전환은 다음 조회 시점의 벌크
  쿼리(`expireAvailableCouponsBefore`)가 담당
    - 같은 트랜잭션 안에서 `coupon.expire()` 호출 후 `throw` 하면 런타임 예외 롤백으로 EXPIRED 변경이 손실되는 트랩 회피                                               
  - 호출 측(PaymentService) 트랜잭션에 참여 (`@Transactional` REQUIRED)
                                                                                                                                                                       
  ### 2. `CouponService.restoreCoupon(couponId, userId)`
  - USED → AVAILABLE 복귀 (단, 복구 시점에 이미 만료 지났으면 EXPIRED로 전환)                                                                                          
  - **Idempotent**: USED가 아닌 상태에서 호출되면 no-op + 경고 로그
    - 이유: 재시도 안전성 + 주문 취소 트랜잭션에서 restore 에러로 환불까지 막히는 상황 방지                                                                            
  - `COUPON_NOT_USED` 같은 신규 예외 코드는 추가하지 않음                                                                                                              
                                                                                                                                                                       
  ### 3. `getMyCoupons` Lazy 만료 전환                                                                                                                                 
  - 조회 전 `CouponRepository.expireAvailableCouponsBefore` UPDATE 쿼리로 해당 사용자의 만료된 AVAILABLE 쿠폰을 일괄 EXPIRED 처리                                      
  - `@Modifying(clearAutomatically=true, flushAutomatically=true)` 적용                                                                                                
  - **벌크 UPDATE 시 `updatedAt` 명시 갱신**: JPQL `@Modifying`은 `@LastModifiedDate` 리스너를 트리거하지 않으므로 SET 절에 `c.updatedAt = :now` 명시                  
  - 조회 시점 기준 상태 일관성 보장 (status 필터 정확도 ↑)                                                                                                             
                                         
  ### 4. 엔티티 / ErrorCode                                                                                                                                            
  - `Coupon`에 `restore()` 도메인 메서드 추가                                                                                                                          
  - ErrorCode 신규 추가 없음 — 기존 `COUPON_NOT_FOUND`, `COUPON_ALREADY_USED`, `COUPON_EXPIRED`, `AUTH_FORBIDDEN` 재사용                                               
                                                                                                                                                                       
  추가로 넣은 것                                                                                                                                                       
                                           
  - 1번에 롤백 트랩 회피 명시 → 이전 리뷰 지적사항 사전 차단                                                                                                           
  - 3번에 updatedAt 수동 갱신 명시 → 마찬가지  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 쿠폰 사용 기능: 보유한 쿠폰을 사용할 수 있습니다.
  * 쿠폰 복원 기능: 사용된 쿠폰을 복원할 수 있습니다.
  * 자동 만료 처리: 만료 기한이 지난 쿠폰이 자동으로 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->