### PR TITLE
채팅방 관련 API 구현

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -1,14 +1,23 @@
 package com.myfave.api.domain.chat.controller;
 
+import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.service.ChatService;
+import com.myfave.api.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/chat")
+@RequestMapping("/chat-room")
 @RequiredArgsConstructor
 public class ChatController {
 
     private final ChatService chatService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ChatRoomInfoResponse>> getChatRoom() {
+        return ResponseEntity.ok(ApiResponse.ok(chatService.getChatRoomInfo()));
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.myfave.api.domain.chat.controller;
 
 import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
+import com.myfave.api.domain.chat.dto.response.ChatRoomCloseResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.service.ChatService;
 import com.myfave.api.global.common.ApiResponse;
@@ -8,8 +9,10 @@ import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,10 +35,22 @@ public class ChatController {
             @RequestParam(defaultValue = "50") int size,
             @RequestParam(required = false) String before) {
 
-        if (authentication == null || authentication instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
 
         return ResponseEntity.ok(ApiResponse.ok(chatService.getMessageHistory(size, before)));
+    }
+
+    @PatchMapping("/close")
+    public ResponseEntity<ApiResponse<ChatRoomCloseResponse>> closeChatRoom(
+            Authentication authentication) {
+
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        Long userId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(new ApiResponse<>(200, "채팅방이 종료되었습니다.", chatService.closeChatRoom(userId)));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.myfave.api.domain.chat.controller;
 
 import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
+import com.myfave.api.domain.chat.dto.response.ChatPreviewResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomCloseResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.service.ChatService;
@@ -40,6 +41,12 @@ public class ChatController {
         }
 
         return ResponseEntity.ok(ApiResponse.ok(chatService.getMessageHistory(size, before)));
+    }
+
+    @GetMapping("/preview")
+    public ResponseEntity<ApiResponse<ChatPreviewResponse>> getChatPreview(
+            @RequestParam(defaultValue = "5") int size) {
+        return ResponseEntity.ok(ApiResponse.ok(chatService.getChatPreview(size)));
     }
 
     @PatchMapping("/close")

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -32,7 +32,7 @@ public class ChatController {
             @RequestParam(defaultValue = "50") int size,
             @RequestParam(required = false) String before) {
 
-        if (authentication == null || !authentication.isAuthenticated()) {
+        if (authentication == null || authentication instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
 

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,6 +48,11 @@ public class ChatController {
     public ResponseEntity<ApiResponse<ChatPreviewResponse>> getChatPreview(
             @RequestParam(defaultValue = "5") int size) {
         return ResponseEntity.ok(ApiResponse.ok(chatService.getChatPreview(size)));
+    }
+
+    @PostMapping("/opentemp")
+    public ResponseEntity<ApiResponse<ChatRoomInfoResponse>> openTempRoom() {
+        return ResponseEntity.ok(ApiResponse.ok(chatService.openTempRoom()));
     }
 
     @PatchMapping("/close")

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -40,6 +40,9 @@ public class ChatController {
         if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
+        if (size < 1 || size > 100) {
+            return ResponseEntity.badRequest().body(ApiResponse.error(ErrorCode.COMMON_INVALID_INPUT));
+        }
 
         return ResponseEntity.ok(ApiResponse.ok(chatService.getMessageHistory(size, before)));
     }
@@ -47,6 +50,9 @@ public class ChatController {
     @GetMapping("/preview")
     public ResponseEntity<ApiResponse<ChatPreviewResponse>> getChatPreview(
             @RequestParam(defaultValue = "5") int size) {
+        if (size < 1 || size > 100) {
+            return ResponseEntity.badRequest().body(ApiResponse.error(ErrorCode.COMMON_INVALID_INPUT));
+        }
         return ResponseEntity.ok(ApiResponse.ok(chatService.getChatPreview(size)));
     }
 

--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatController.java
@@ -1,12 +1,17 @@
 package com.myfave.api.domain.chat.controller;
 
+import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.service.ChatService;
 import com.myfave.api.global.common.ApiResponse;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,5 +24,18 @@ public class ChatController {
     @GetMapping
     public ResponseEntity<ApiResponse<ChatRoomInfoResponse>> getChatRoom() {
         return ResponseEntity.ok(ApiResponse.ok(chatService.getChatRoomInfo()));
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<ApiResponse<ChatHistoryResponse>> getMessages(
+            Authentication authentication,
+            @RequestParam(defaultValue = "50") int size,
+            @RequestParam(required = false) String before) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        return ResponseEntity.ok(ApiResponse.ok(chatService.getMessageHistory(size, before)));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatHistoryResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatHistoryResponse.java
@@ -21,7 +21,7 @@ public class ChatHistoryResponse {
         private String messageId;
         private Long senderId;
         private String senderNickname;
-        private boolean isInfluencer;
+        private Boolean isInfluencer;
         private String content;
         private ZonedDateTime createdAt;
     }

--- a/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatHistoryResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.myfave.api.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatHistoryResponse {
+
+    private List<MessageItem> messages;
+    private boolean hasMore;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MessageItem {
+        private String messageId;
+        private Long senderId;
+        private String senderNickname;
+        private boolean isInfluencer;
+        private String content;
+        private ZonedDateTime createdAt;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatPreviewResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatPreviewResponse.java
@@ -1,0 +1,26 @@
+package com.myfave.api.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatPreviewResponse {
+
+    private Boolean isActive;
+    private int participantCount;
+    private List<PreviewMessage> recentMessages;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PreviewMessage {
+        private String senderNickname;
+        private String content;
+        private ZonedDateTime createdAt;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatRoomCloseResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatRoomCloseResponse.java
@@ -1,0 +1,19 @@
+package com.myfave.api.domain.chat.dto.response;
+
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomCloseResponse {
+
+    private Boolean isActive;
+    private ZonedDateTime closedAt;
+
+    public static ChatRoomCloseResponse from(ChatRoom chatRoom) {
+        return new ChatRoomCloseResponse(chatRoom.getIsActive(), chatRoom.getClosedAt());
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatRoomInfoResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,0 +1,26 @@
+package com.myfave.api.domain.chat.dto.response;
+
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomInfoResponse {
+
+    private Long id;
+    private Boolean isActive;
+    private int participantCount;
+    private ZonedDateTime createdAt;
+
+    public static ChatRoomInfoResponse from(ChatRoom chatRoom, int participantCount) {
+        return new ChatRoomInfoResponse(
+                chatRoom.getChatRoomId(),
+                chatRoom.getIsActive(),
+                participantCount,
+                chatRoom.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/repository/ChatRoomRepository.java
@@ -10,4 +10,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     // 판매 이벤트의 활성화된 채팅방
     Optional<ChatRoom> findBySaleEventAndIsActiveTrue(SaleEvent saleEvent);
+
+    // 활성화된 채팅방 조회
+    Optional<ChatRoom> findByIsActiveTrue();
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/repository/ChatRoomRepository.java
@@ -13,4 +13,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     // 활성화된 채팅방 조회
     Optional<ChatRoom> findByIsActiveTrue();
+
+    // 최근 채팅방 조회 (isActive 무관) - 404 vs 409 구분용
+    Optional<ChatRoom> findTopByOrderByChatRoomIdDesc();
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -11,6 +11,10 @@ import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.domain.user.entity.User;
+import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
+import com.myfave.api.domain.saleevent.entity.SaleEvent;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +37,8 @@ public class ChatService {
     private final SessionRegistry sessionRegistry;
     private final ChatMessageService chatMessageService;
     private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final SaleEventRepository saleEventRepository;
 
     @Value("${influencer.user-id}")
     private Long influencerUserId;
@@ -102,6 +108,28 @@ public class ChatService {
         }
 
         return new ChatPreviewResponse(chatRoom.getIsActive(), participantCount, recentMessages);
+    }
+
+    @Transactional
+    public ChatRoomInfoResponse openTempRoom() {
+        chatRoomRepository.findByIsActiveTrue().ifPresent(chatRoom -> {
+            throw new CustomException(ErrorCode.COMMON_INVALID_INPUT);
+        });
+
+        User user = userRepository.findById(influencerUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        SaleEvent saleEvent = saleEventRepository.findAll().stream().findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMON_INVALID_INPUT));
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .user(user)
+                .saleEvent(saleEvent)
+                .build();
+        
+        chatRoomRepository.save(chatRoom);
+        
+        return ChatRoomInfoResponse.from(chatRoom, 0);
     }
 
     @Transactional

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -46,9 +46,14 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findByIsActiveTrue()
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        ZonedDateTime cursor = before != null
-                ? ZonedDateTime.parse(before)
-                : ZonedDateTime.now().plusSeconds(1);
+        ZonedDateTime cursor;
+        try {
+            cursor = before != null
+                    ? ZonedDateTime.parse(before)
+                    : ZonedDateTime.now().plusSeconds(1);
+        } catch (java.time.format.DateTimeParseException e) {
+            throw new CustomException(ErrorCode.COMMON_INVALID_INPUT);
+        }
 
         List<StoredMessage> parsed = parseMessages(chatRoom.getChatRoomId(), cursor);
 

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -77,7 +78,7 @@ public class ChatService {
                     .messageId(p.getMessageId())
                     .senderId(p.getUserId())
                     .senderNickname(p.getNickname())
-                    .isInfluencer(p.getUserId().equals(influencerUserId))
+                    .isInfluencer(Objects.equals(p.getUserId(), influencerUserId))
                     .content(p.getContent())
                     .createdAt(p.getSentAt())
                     .build());

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -1,6 +1,11 @@
 package com.myfave.api.domain.chat.service;
 
+import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
+import com.myfave.api.domain.chat.entity.ChatRoom;
 import com.myfave.api.domain.chat.repository.ChatRoomRepository;
+import com.myfave.api.global.config.SessionRegistry;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final SessionRegistry sessionRegistry;
+
+    public ChatRoomInfoResponse getChatRoomInfo() {
+        ChatRoom chatRoom = chatRoomRepository.findByIsActiveTrue()
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        int participantCount = sessionRegistry.getParticipantCount(chatRoom.getChatRoomId());
+        return ChatRoomInfoResponse.from(chatRoom, participantCount);
+    }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -1,15 +1,27 @@
 package com.myfave.api.domain.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.entity.ChatRoom;
 import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -17,11 +29,82 @@ public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final SessionRegistry sessionRegistry;
+    private final ChatMessageService chatMessageService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${influencer.user-id}")
+    private Long influencerUserId;
 
     public ChatRoomInfoResponse getChatRoomInfo() {
         ChatRoom chatRoom = chatRoomRepository.findByIsActiveTrue()
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         int participantCount = sessionRegistry.getParticipantCount(chatRoom.getChatRoomId());
         return ChatRoomInfoResponse.from(chatRoom, participantCount);
+    }
+
+    public ChatHistoryResponse getMessageHistory(int size, String before) {
+        ChatRoom chatRoom = chatRoomRepository.findByIsActiveTrue()
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        ZonedDateTime cursor = before != null
+                ? ZonedDateTime.parse(before)
+                : ZonedDateTime.now().plusSeconds(1);
+
+        List<StoredMessage> parsed = parseMessages(chatRoom.getChatRoomId(), cursor);
+
+        int total = parsed.size();
+        int fromIndex = Math.max(0, total - size);
+        List<StoredMessage> page = parsed.subList(fromIndex, total);
+        boolean hasMore = fromIndex > 0;
+
+        List<ChatHistoryResponse.MessageItem> items = new ArrayList<>();
+        for (StoredMessage msg : page) {
+            StoredPayload p = msg.getPayload();
+            items.add(ChatHistoryResponse.MessageItem.builder()
+                    .messageId(p.getMessageId())
+                    .senderId(p.getUserId())
+                    .senderNickname(p.getNickname())
+                    .isInfluencer(p.getUserId().equals(influencerUserId))
+                    .content(p.getContent())
+                    .createdAt(p.getSentAt())
+                    .build());
+        }
+
+        return new ChatHistoryResponse(items, hasMore);
+    }
+
+    List<StoredMessage> parseMessages(Long roomId, ZonedDateTime cursor) {
+        List<String> rawMessages = chatMessageService.getHistory(roomId);
+        List<StoredMessage> result = new ArrayList<>();
+
+        for (String json : rawMessages) {
+            try {
+                StoredMessage msg = objectMapper.readValue(json, StoredMessage.class);
+                if (msg.getPayload() == null) continue;
+                if (!"NEW_MESSAGE".equals(msg.getType())) continue;
+                if (!msg.getPayload().getSentAt().isBefore(cursor)) continue;
+                result.add(msg);
+            } catch (JsonProcessingException e) {
+                log.warn("메시지 파싱 실패: {}", json);
+            }
+        }
+        return result;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    static class StoredMessage {
+        private String type;
+        private StoredPayload payload;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    static class StoredPayload {
+        private String messageId;
+        private Long userId;
+        private String nickname;
+        private String content;
+        private ZonedDateTime sentAt;
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -80,6 +80,30 @@ public class ChatService {
         return new ChatHistoryResponse(items, hasMore);
     }
 
+    public ChatPreviewResponse getChatPreview(int size) {
+        ChatRoom chatRoom = chatRoomRepository.findByIsActiveTrue()
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        int participantCount = sessionRegistry.getParticipantCount(chatRoom.getChatRoomId());
+
+        List<StoredMessage> allParsed = parseMessages(chatRoom.getChatRoomId(), ZonedDateTime.now().plusSeconds(1));
+        int total = allParsed.size();
+        int fromIndex = Math.max(0, total - size);
+        List<StoredMessage> page = allParsed.subList(fromIndex, total);
+
+        List<ChatPreviewResponse.PreviewMessage> recentMessages = new ArrayList<>();
+        for (StoredMessage msg : page) {
+            StoredPayload p = msg.getPayload();
+            recentMessages.add(ChatPreviewResponse.PreviewMessage.builder()
+                    .senderNickname(p.getNickname())
+                    .content(p.getContent())
+                    .createdAt(p.getSentAt())
+                    .build());
+        }
+
+        return new ChatPreviewResponse(chatRoom.getIsActive(), participantCount, recentMessages);
+    }
+
     @Transactional
     public ChatRoomCloseResponse closeChatRoom(Long requestUserId) {
         ChatRoom chatRoom = chatRoomRepository.findTopByOrderByChatRoomIdDesc()
@@ -99,40 +123,6 @@ public class ChatService {
 
     List<StoredMessage> parseMessages(Long roomId, ZonedDateTime cursor) {
         List<String> rawMessages = chatMessageService.getHistory(roomId);
-        List<StoredMessage> result = new ArrayList<>();
-
-        for (String json : rawMessages) {
-            try {
-                StoredMessage msg = objectMapper.readValue(json, StoredMessage.class);
-                if (msg.getPayload() == null) continue;
-                if (!"NEW_MESSAGE".equals(msg.getType())) continue;
-                if (!msg.getPayload().getSentAt().isBefore(cursor)) continue;
-                result.add(msg);
-            } catch (JsonProcessingException e) {
-                log.warn("메시지 파싱 실패: {}", json);
-            }
-        }
-        return result;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    static class StoredMessage {
-        private String type;
-        private StoredPayload payload;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    static class StoredPayload {
-        private String messageId;
-        private Long userId;
-        private String nickname;
-        private String content;
-        private ZonedDateTime sentAt;
-    }
-}
-     List<String> rawMessages = chatMessageService.getHistory(roomId);
         List<StoredMessage> result = new ArrayList<>();
 
         for (String json : rawMessages) {

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.myfave.api.domain.chat.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
+import com.myfave.api.domain.chat.dto.response.ChatRoomCloseResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.entity.ChatRoom;
 import com.myfave.api.domain.chat.repository.ChatRoomRepository;
@@ -76,6 +77,23 @@ public class ChatService {
         }
 
         return new ChatHistoryResponse(items, hasMore);
+    }
+
+    @Transactional
+    public ChatRoomCloseResponse closeChatRoom(Long requestUserId) {
+        ChatRoom chatRoom = chatRoomRepository.findTopByOrderByChatRoomIdDesc()
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.getIsActive()) {
+            throw new CustomException(ErrorCode.CHAT_ROOM_ALREADY_CLOSED);
+        }
+
+        if (!requestUserId.equals(influencerUserId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        chatRoom.close();
+        return ChatRoomCloseResponse.from(chatRoom);
     }
 
     List<StoredMessage> parseMessages(Long roomId, ZonedDateTime cursor) {

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.myfave.api.domain.chat.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
+import com.myfave.api.domain.chat.dto.response.ChatPreviewResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomCloseResponse;
 import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
 import com.myfave.api.domain.chat.entity.ChatRoom;
@@ -98,6 +99,40 @@ public class ChatService {
 
     List<StoredMessage> parseMessages(Long roomId, ZonedDateTime cursor) {
         List<String> rawMessages = chatMessageService.getHistory(roomId);
+        List<StoredMessage> result = new ArrayList<>();
+
+        for (String json : rawMessages) {
+            try {
+                StoredMessage msg = objectMapper.readValue(json, StoredMessage.class);
+                if (msg.getPayload() == null) continue;
+                if (!"NEW_MESSAGE".equals(msg.getType())) continue;
+                if (!msg.getPayload().getSentAt().isBefore(cursor)) continue;
+                result.add(msg);
+            } catch (JsonProcessingException e) {
+                log.warn("메시지 파싱 실패: {}", json);
+            }
+        }
+        return result;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    static class StoredMessage {
+        private String type;
+        private StoredPayload payload;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    static class StoredPayload {
+        private String messageId;
+        private Long userId;
+        private String nickname;
+        private String content;
+        private ZonedDateTime sentAt;
+    }
+}
+     List<String> rawMessages = chatMessageService.getHistory(roomId);
         List<StoredMessage> result = new ArrayList<>();
 
         for (String json : rawMessages) {

--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                                 "/auth/**",        // context-path(/api/v1) 제외한 경로로 매칭
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/ws/**"
+                                "/ws/**",
+                                "/chat-room/opentemp"
                         ).permitAll()
                         .anyRequest().permitAll()   // (JWT 인증 필요).anyRequest().authenticated() ㅣ (JWT 없이 모든 요청 허용) .anyRequest().permitAll()
                 )

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceCloseRoomTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceCloseRoomTest.java
@@ -1,0 +1,115 @@
+package com.myfave.api.domain.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.myfave.api.domain.chat.dto.response.ChatRoomCloseResponse;
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import com.myfave.api.domain.chat.repository.ChatRoomRepository;
+import com.myfave.api.global.config.SessionRegistry;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceCloseRoomTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    private ChatService chatService;
+
+    private static final Long INFLUENCER_ID = 1L;
+    private static final Long REGULAR_USER_ID = 99L;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        ReflectionTestUtils.setField(chatService, "influencerUserId", INFLUENCER_ID);
+    }
+
+    @Test
+    @DisplayName("인플루언서가 활성 채팅방을 정상 종료한다")
+    void closeChatRoom_success() {
+        ChatRoom chatRoom = buildRoom(5L, true);
+        given(chatRoomRepository.findTopByOrderByChatRoomIdDesc()).willReturn(Optional.of(chatRoom));
+
+        ChatRoomCloseResponse response = chatService.closeChatRoom(INFLUENCER_ID);
+
+        assertThat(response.getIsActive()).isFalse();
+        assertThat(response.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("인플루언서가 아닌 사용자가 요청하면 AUTH_FORBIDDEN 예외")
+    void closeChatRoom_forbidden() {
+        ChatRoom chatRoom = buildRoom(5L, true);
+        given(chatRoomRepository.findTopByOrderByChatRoomIdDesc()).willReturn(Optional.of(chatRoom));
+
+        assertThatThrownBy(() -> chatService.closeChatRoom(REGULAR_USER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("채팅방이 아예 없으면 CHAT_ROOM_NOT_FOUND 예외")
+    void closeChatRoom_notFound() {
+        given(chatRoomRepository.findTopByOrderByChatRoomIdDesc()).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chatService.closeChatRoom(INFLUENCER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("이미 종료된 채팅방이면 CHAT_ROOM_ALREADY_CLOSED 예외")
+    void closeChatRoom_alreadyClosed() {
+        ChatRoom closedRoom = buildRoom(5L, false);
+        given(chatRoomRepository.findTopByOrderByChatRoomIdDesc()).willReturn(Optional.of(closedRoom));
+
+        assertThatThrownBy(() -> chatService.closeChatRoom(INFLUENCER_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CHAT_ROOM_ALREADY_CLOSED));
+    }
+
+    private ChatRoom buildRoom(Long id, boolean active) {
+        try {
+            var constructor = ChatRoom.class.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            ChatRoom room = (ChatRoom) constructor.newInstance();
+            var f1 = ChatRoom.class.getDeclaredField("chatRoomId");
+            f1.setAccessible(true);
+            f1.set(room, id);
+            var f2 = ChatRoom.class.getDeclaredField("isActive");
+            f2.setAccessible(true);
+            f2.set(room, active);
+            return room;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceCloseRoomTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceCloseRoomTest.java
@@ -9,6 +9,8 @@ import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,12 @@ class ChatServiceCloseRoomTest {
     @Mock
     private ChatMessageService chatMessageService;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SaleEventRepository saleEventRepository;
+
     private ChatService chatService;
 
     private static final Long INFLUENCER_ID = 1L;
@@ -45,7 +53,7 @@ class ChatServiceCloseRoomTest {
         ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper, userRepository, saleEventRepository);
         ReflectionTestUtils.setField(chatService, "influencerUserId", INFLUENCER_ID);
     }
 

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetMessageHistoryTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetMessageHistoryTest.java
@@ -9,6 +9,8 @@ import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,12 @@ class ChatServiceGetMessageHistoryTest {
     @Mock
     private ChatMessageService chatMessageService;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SaleEventRepository saleEventRepository;
+
     private ChatService chatService;
 
     @BeforeEach
@@ -43,7 +51,7 @@ class ChatServiceGetMessageHistoryTest {
         ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper, userRepository, saleEventRepository);
         ReflectionTestUtils.setField(chatService, "influencerUserId", 1L);
     }
 

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetMessageHistoryTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetMessageHistoryTest.java
@@ -1,0 +1,146 @@
+package com.myfave.api.domain.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.myfave.api.domain.chat.dto.response.ChatHistoryResponse;
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import com.myfave.api.domain.chat.repository.ChatRoomRepository;
+import com.myfave.api.global.config.SessionRegistry;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceGetMessageHistoryTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    private ChatService chatService;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        ReflectionTestUtils.setField(chatService, "influencerUserId", 1L);
+    }
+
+    @Test
+    @DisplayName("메시지가 있을 때 역직렬화하여 isInfluencer 포함 반환")
+    void getMessageHistory_success() {
+        ChatRoom chatRoom = buildRoom(10L);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+
+        String msg1 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"uuid-1\",\"userId\":1,\"nickname\":\"MyFave_Official\",\"content\":\"안녕하세요\",\"sentAt\":\"2026-03-22T12:00:00Z\"}}";
+        String msg2 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"uuid-2\",\"userId\":42,\"nickname\":\"패션왕\",\"content\":\"좋아요\",\"sentAt\":\"2026-03-22T12:01:00Z\"}}";
+        given(chatMessageService.getHistory(10L)).willReturn(List.of(msg1, msg2));
+
+        ChatHistoryResponse response = chatService.getMessageHistory(50, null);
+
+        assertThat(response.getMessages()).hasSize(2);
+        assertThat(response.getMessages().get(0).isInfluencer()).isTrue();
+        assertThat(response.getMessages().get(1).isInfluencer()).isFalse();
+        assertThat(response.isHasMore()).isFalse();
+    }
+
+    @Test
+    @DisplayName("size보다 메시지가 많을 때 hasMore=true, 최근 size개 반환")
+    void getMessageHistory_hasMore() {
+        ChatRoom chatRoom = buildRoom(10L);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+
+        String msg1 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":5,\"nickname\":\"A\",\"content\":\"1\",\"sentAt\":\"2026-03-22T11:00:00Z\"}}";
+        String msg2 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m2\",\"userId\":5,\"nickname\":\"A\",\"content\":\"2\",\"sentAt\":\"2026-03-22T11:01:00Z\"}}";
+        String msg3 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m3\",\"userId\":5,\"nickname\":\"A\",\"content\":\"3\",\"sentAt\":\"2026-03-22T11:02:00Z\"}}";
+        given(chatMessageService.getHistory(10L)).willReturn(List.of(msg1, msg2, msg3));
+
+        ChatHistoryResponse response = chatService.getMessageHistory(2, null);
+
+        assertThat(response.getMessages()).hasSize(2);
+        assertThat(response.isHasMore()).isTrue();
+        assertThat(response.getMessages().get(0).getMessageId()).isEqualTo("m2");
+        assertThat(response.getMessages().get(1).getMessageId()).isEqualTo("m3");
+    }
+
+    @Test
+    @DisplayName("before 커서 이전 메시지만 반환")
+    void getMessageHistory_withBeforeCursor() {
+        ChatRoom chatRoom = buildRoom(10L);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+
+        String msg1 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":5,\"nickname\":\"A\",\"content\":\"1\",\"sentAt\":\"2026-03-22T11:00:00Z\"}}";
+        String msg2 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m2\",\"userId\":5,\"nickname\":\"A\",\"content\":\"2\",\"sentAt\":\"2026-03-22T12:00:00Z\"}}";
+        given(chatMessageService.getHistory(10L)).willReturn(List.of(msg1, msg2));
+
+        ChatHistoryResponse response = chatService.getMessageHistory(50, "2026-03-22T11:30:00Z");
+
+        assertThat(response.getMessages()).hasSize(1);
+        assertThat(response.getMessages().get(0).getMessageId()).isEqualTo("m1");
+    }
+
+    @Test
+    @DisplayName("NEW_MESSAGE 외 타입은 히스토리에서 제외")
+    void getMessageHistory_skipsNonChatMessages() {
+        ChatRoom chatRoom = buildRoom(10L);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+
+        String participantMsg = "{\"type\":\"PARTICIPANT_COUNT\",\"payload\":{\"count\":5}}";
+        String chatMsg = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":5,\"nickname\":\"A\",\"content\":\"hi\",\"sentAt\":\"2026-03-22T11:00:00Z\"}}";
+        given(chatMessageService.getHistory(10L)).willReturn(List.of(participantMsg, chatMsg));
+
+        ChatHistoryResponse response = chatService.getMessageHistory(50, null);
+
+        assertThat(response.getMessages()).hasSize(1);
+        assertThat(response.getMessages().get(0).getMessageId()).isEqualTo("m1");
+    }
+
+    @Test
+    @DisplayName("활성 채팅방 없으면 CHAT_ROOM_NOT_FOUND 예외")
+    void getMessageHistory_roomNotFound() {
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chatService.getMessageHistory(50, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoom buildRoom(Long id) {
+        try {
+            var constructor = ChatRoom.class.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            ChatRoom room = (ChatRoom) constructor.newInstance();
+            var f1 = ChatRoom.class.getDeclaredField("chatRoomId");
+            f1.setAccessible(true);
+            f1.set(room, id);
+            var f2 = ChatRoom.class.getDeclaredField("isActive");
+            f2.setAccessible(true);
+            f2.set(room, true);
+            return room;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
@@ -9,6 +9,8 @@ import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,12 @@ class ChatServiceGetPreviewTest {
     @Mock
     private ChatMessageService chatMessageService;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SaleEventRepository saleEventRepository;
+
     private ChatService chatService;
 
     @BeforeEach
@@ -43,7 +51,7 @@ class ChatServiceGetPreviewTest {
         ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper, userRepository, saleEventRepository);
         ReflectionTestUtils.setField(chatService, "influencerUserId", 1L);
     }
 

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
@@ -130,7 +130,9 @@ class ChatServiceGetPreviewTest {
 
     private ChatRoom buildRoom(Long id, boolean active) {
         try {
-            ChatRoom room = (ChatRoom) ChatRoom.class.getDeclaredConstructors()[0].newInstance();
+            var constructor = ChatRoom.class.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            ChatRoom room = (ChatRoom) constructor.newInstance();
             var f1 = ChatRoom.class.getDeclaredField("chatRoomId");
             f1.setAccessible(true);
             f1.set(room, id);

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetPreviewTest.java
@@ -1,0 +1,145 @@
+package com.myfave.api.domain.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.myfave.api.domain.chat.dto.response.ChatPreviewResponse;
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import com.myfave.api.domain.chat.repository.ChatRoomRepository;
+import com.myfave.api.global.config.SessionRegistry;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceGetPreviewTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    private ChatService chatService;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        chatService = new ChatService(chatRoomRepository, sessionRegistry, chatMessageService, objectMapper);
+        ReflectionTestUtils.setField(chatService, "influencerUserId", 1L);
+    }
+
+    @Test
+    @DisplayName("활성 채팅방이 존재할 때 채팅방 미리보기 정보를 성공적으로 반환한다")
+    void getChatPreview_success() {
+        // given
+        ChatRoom chatRoom = buildRoom(7L, true);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+        given(sessionRegistry.getParticipantCount(7L)).willReturn(128);
+
+        String msg1 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":42,\"nickname\":\"유저42\",\"content\":\"첫번째 메시지\",\"sentAt\":\"2026-03-22T12:05:30Z\"}}";
+        String msg2 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m2\",\"userId\":1,\"nickname\":\"MyFave_Official\",\"content\":\"두번째\",\"sentAt\":\"2026-03-22T12:06:00Z\"}}";
+        given(chatMessageService.getHistory(7L)).willReturn(List.of(msg1, msg2));
+
+        // when
+        ChatPreviewResponse response = chatService.getChatPreview(5);
+
+        // then
+        assertThat(response.getIsActive()).isTrue();
+        assertThat(response.getParticipantCount()).isEqualTo(128);
+        assertThat(response.getRecentMessages()).hasSize(2);
+        assertThat(response.getRecentMessages().get(0).getSenderNickname()).isEqualTo("유저42");
+        assertThat(response.getRecentMessages().get(0).getContent()).isEqualTo("첫번째 메시지");
+    }
+
+    @Test
+    @DisplayName("요청된 size보다 많은 메시지가 있으면 최근 size개만 반환한다")
+    void getChatPreview_limitsToSize() {
+        // given
+        ChatRoom chatRoom = buildRoom(7L, true);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+        given(sessionRegistry.getParticipantCount(7L)).willReturn(10);
+
+        // 3개의 메시지
+        String msg1 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":5,\"nickname\":\"A\",\"content\":\"1\",\"sentAt\":\"2026-03-22T11:00:00Z\"}}";
+        String msg2 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m2\",\"userId\":5,\"nickname\":\"A\",\"content\":\"2\",\"sentAt\":\"2026-03-22T11:01:00Z\"}}";
+        String msg3 = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m3\",\"userId\":5,\"nickname\":\"A\",\"content\":\"3\",\"sentAt\":\"2026-03-22T11:02:00Z\"}}";
+        given(chatMessageService.getHistory(7L)).willReturn(List.of(msg1, msg2, msg3));
+
+        // when
+        ChatPreviewResponse response = chatService.getChatPreview(2);
+
+        // then
+        assertThat(response.getRecentMessages()).hasSize(2);
+        // 최근 2개 (msg2, msg3)
+        assertThat(response.getRecentMessages().get(0).getContent()).isEqualTo("2");
+        assertThat(response.getRecentMessages().get(1).getContent()).isEqualTo("3");
+    }
+
+    @Test
+    @DisplayName("messageId와 senderId등은 제외하고 응답한다(PreviewMessage DTO 구조 검증)")
+    void getChatPreview_responseFieldsAreNarrowed() {
+        // given
+        ChatRoom chatRoom = buildRoom(7L, true);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+        given(sessionRegistry.getParticipantCount(7L)).willReturn(1);
+
+        String msg = "{\"type\":\"NEW_MESSAGE\",\"payload\":{\"messageId\":\"m1\",\"userId\":1,\"nickname\":\"MyFave\",\"content\":\"hello\",\"sentAt\":\"2026-03-22T12:00:00Z\"}}";
+        given(chatMessageService.getHistory(7L)).willReturn(List.of(msg));
+
+        // when
+        ChatPreviewResponse response = chatService.getChatPreview(5);
+
+        // then
+        ChatPreviewResponse.PreviewMessage pm = response.getRecentMessages().get(0);
+        assertThat(pm.getSenderNickname()).isEqualTo("MyFave");
+        assertThat(pm.getContent()).isEqualTo("hello");
+        assertThat(pm.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("활성 채팅방이 없으면 예외를 발생시킨다")
+    void getChatPreview_notFound() {
+        // given
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chatService.getChatPreview(5))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoom buildRoom(Long id, boolean active) {
+        try {
+            ChatRoom room = (ChatRoom) ChatRoom.class.getDeclaredConstructors()[0].newInstance();
+            var f1 = ChatRoom.class.getDeclaredField("chatRoomId");
+            f1.setAccessible(true);
+            f1.set(room, id);
+            var f2 = ChatRoom.class.getDeclaredField("isActive");
+            f2.setAccessible(true);
+            f2.set(room, active);
+            return room;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
@@ -6,6 +6,8 @@ import com.myfave.api.domain.chat.repository.ChatRoomRepository;
 import com.myfave.api.global.config.SessionRegistry;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
@@ -46,6 +46,7 @@ class ChatServiceGetRoomInfoTest {
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getIsActive()).isTrue();
         assertThat(response.getParticipantCount()).isEqualTo(42);
+        assertThat(response.getCreatedAt()).isNull(); // 테스트 빌더에서 createdAt 미설정 — 필드 존재 확인
     }
 
     @Test

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
@@ -1,0 +1,82 @@
+package com.myfave.api.domain.chat.service;
+
+import com.myfave.api.domain.chat.dto.response.ChatRoomInfoResponse;
+import com.myfave.api.domain.chat.entity.ChatRoom;
+import com.myfave.api.domain.chat.repository.ChatRoomRepository;
+import com.myfave.api.global.config.SessionRegistry;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceGetRoomInfoTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    @Test
+    @DisplayName("활성화된 채팅방이 있을 때 정보와 참가자 수를 반환한다")
+    void getChatRoomInfo_success() {
+        // given
+        ChatRoom chatRoom = buildActiveChatRoom(1L);
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.of(chatRoom));
+        given(sessionRegistry.getParticipantCount(1L)).willReturn(42);
+
+        // when
+        ChatRoomInfoResponse response = chatService.getChatRoomInfo();
+
+        // then
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getIsActive()).isTrue();
+        assertThat(response.getParticipantCount()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("활성화된 채팅방이 없을 때 CHAT_ROOM_NOT_FOUND 예외를 던진다")
+    void getChatRoomInfo_notFound() {
+        // given
+        given(chatRoomRepository.findByIsActiveTrue()).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> chatService.getChatRoomInfo())
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoom buildActiveChatRoom(Long id) {
+        try {
+            var constructor = ChatRoom.class.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            ChatRoom room = (ChatRoom) constructor.newInstance();
+            setField(room, "chatRoomId", id);
+            setField(room, "isActive", true);
+            return room;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        var field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '@/shared/api/axios'
+import type { ApiResponse } from '@/shared/api/types'
+import type { ChatRoomInfo, ChatHistoryResponse, ChatPreviewResponse } from './types'
+
+export const chatApi = {
+  getRoomInfo: async (): Promise<ChatRoomInfo> => {
+    const { data } = await apiClient.get<ApiResponse<ChatRoomInfo>>('/chat-room')
+    return data.data
+  },
+
+  getMessageHistory: async (size = 50, before?: string): Promise<ChatHistoryResponse> => {
+    const { data } = await apiClient.get<ApiResponse<ChatHistoryResponse>>('/chat-room/messages', {
+      params: { size, ...(before !== undefined ? { before } : {}) },
+    })
+    return data.data
+  },
+
+  getPreview: async (size = 5): Promise<ChatPreviewResponse> => {
+    const { data } = await apiClient.get<ApiResponse<ChatPreviewResponse>>('/chat-room/preview', {
+      params: { size },
+    })
+    return data.data
+  },
+}

--- a/frontend/src/features/chat/hooks.ts
+++ b/frontend/src/features/chat/hooks.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { chatApi } from './api'
+
+export function useChatRoomInfo() {
+  return useQuery({
+    queryKey: ['chat', 'room'],
+    queryFn: chatApi.getRoomInfo,
+    staleTime: 10_000,
+    retry: false,
+  })
+}
+
+export function useChatMessageHistory(enabled: boolean, size = 50) {
+  return useQuery({
+    queryKey: ['chat', 'history', size],
+    queryFn: () => chatApi.getMessageHistory(size),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  })
+}
+
+export function useChatPreview(size = 5) {
+  return useQuery({
+    queryKey: ['chat', 'preview', size],
+    queryFn: () => chatApi.getPreview(size),
+    staleTime: 30_000,
+    retry: false,
+  })
+}

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -1,0 +1,32 @@
+export interface ChatRoomInfo {
+  id: number
+  isActive: boolean
+  participantCount: number
+  createdAt: string
+}
+
+export interface ChatHistoryMessage {
+  messageId: string
+  senderId: number
+  senderNickname: string
+  isInfluencer: boolean
+  content: string
+  createdAt: string
+}
+
+export interface ChatHistoryResponse {
+  messages: ChatHistoryMessage[]
+  hasMore: boolean
+}
+
+export interface ChatPreviewMessage {
+  senderNickname: string
+  content: string
+  createdAt: string
+}
+
+export interface ChatPreviewResponse {
+  isActive: boolean
+  participantCount: number
+  recentMessages: ChatPreviewMessage[]
+}

--- a/frontend/src/pages/LiveChatPage.tsx
+++ b/frontend/src/pages/LiveChatPage.tsx
@@ -1,7 +1,10 @@
+// frontend/src/pages/LiveChatPage.tsx
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Client } from '@stomp/stompjs'
 import SockJS from 'sockjs-client'
 import { UserIcon } from '@/shared/components/UserIcon'
+import { useChatRoomInfo, useChatMessageHistory } from '@/features/chat/hooks'
+import type { ChatHistoryMessage } from '@/features/chat/types'
 
 const THROTTLE_MS = 3000
 const BEAR_VARIANTS = [1, 3, 5, 6, 7, 10] as const
@@ -15,7 +18,7 @@ function getVariantFromNickname(nickname: string): number {
 }
 
 interface Message {
-  id: number
+  id: string | number
   user: string
   text: string
   avatarType: 'bear' | 'human' | 'seller'
@@ -24,91 +27,69 @@ interface Message {
   timestamp: string
 }
 
-const INITIAL_MESSAGES: Message[] = [
-  {
-    id: 1,
-    user: '복숭아맛구름',
-    text: '드디어 오늘이다 ㅠㅠ 언니 트위드 자켓 기다렸어요!',
-    avatarType: 'bear',
-    avatarVariant: 5,
-    timestamp: '오후 5:32',
-  },
-  {
-    id: 2,
-    user: '민트초코는진리',
-    text: '혹시 니트 카디건 사이즈 프리인가요??',
-    avatarType: 'bear',
-    avatarVariant: 3,
-    timestamp: '오후 5:35',
-  },
-  {
-    id: 3,
-    user: 'My Fave 공식',
-    text: '네! 앙고라 니트 카디건 사이즈 프리이고 40% 세일 중입니다💕 판매 시작되면 바로 확인해주세요!',
-    avatarType: 'seller',
-    avatarVariant: 1,
-    isOfficial: true,
-    timestamp: '오후 5:36',
-  },
-  {
-    id: 4,
-    user: '라벤더무드',
-    text: '10분 전에 알림 한번 더 와주면 좋겠다!',
-    avatarType: 'bear',
-    avatarVariant: 7,
-    timestamp: '오후 5:38',
-  },
-  {
-    id: 5,
-    user: '바닐라라떼',
-    text: '쿠폰 적용 중복으로 되나요?',
-    avatarType: 'bear',
-    avatarVariant: 1,
-    timestamp: '오후 5:40',
-  },
-  {
-    id: 6,
-    user: 'My Fave 공식',
-    text: '아쉽게도 쿠폰은 1주문당 1개만 적용 가능합니다. 하지만 무료배송 혜택은 자동 적용되니 걱정 마세요! 😊',
-    avatarType: 'seller',
-    avatarVariant: 1,
-    isOfficial: true,
-    timestamp: '오후 5:41',
-  },
-  {
-    id: 7,
-    user: '포근한겨울',
-    text: '지난번 원피스 너무 잘 샀어요! 이번에도 기대중 ㅎㅎ',
-    avatarType: 'bear',
-    avatarVariant: 6,
-    timestamp: '오후 5:43',
-  },
-]
+function historyToMessage(msg: ChatHistoryMessage): Message {
+  return {
+    id: msg.messageId,
+    user: msg.senderNickname,
+    text: msg.content,
+    avatarType: msg.isInfluencer ? 'seller' : 'bear',
+    avatarVariant: msg.isInfluencer ? 1 : getVariantFromNickname(msg.senderNickname),
+    isOfficial: msg.isInfluencer,
+    timestamp: new Date(msg.createdAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+  }
+}
+
+function InactiveRoomScreen() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center bg-white">
+      <div className="flex flex-col items-center gap-4 px-8 text-center">
+        <p className="font-noto text-[16px] font-bold text-dark-text">채팅방이 곧 활성화 됩니다</p>
+        <p className="font-noto text-[12px] text-muted-text">오픈 30분 전에 채팅방이 열립니다</p>
+      </div>
+    </div>
+  )
+}
 
 export function LiveChatPage() {
-  const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES)
+  const { data: roomInfo, isLoading: isRoomLoading, isError: isRoomError } = useChatRoomInfo()
+  const { data: historyData } = useChatMessageHistory(roomInfo?.isActive === true)
+
+  const [messages, setMessages] = useState<Message[]>([])
   const [inputText, setInputText] = useState('')
   const [isNoticeOpen, setIsNoticeOpen] = useState(true)
-  const [participantCount, setParticipantCount] = useState(5123)
+  const [participantCount, setParticipantCount] = useState(0)
   const [isConnected, setIsConnected] = useState(false)
   const [isCooldown, setIsCooldown] = useState(false)
+  const [isRoomClosed, setIsRoomClosed] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const stompClient = useRef<Client | null>(null)
   const lastSendTimeRef = useRef<number>(0)
 
   useEffect(() => {
+    if (roomInfo?.participantCount != null) {
+      setParticipantCount(roomInfo.participantCount)
+    }
+  }, [roomInfo?.participantCount])
+
+  useEffect(() => {
+    if (!historyData?.messages.length) return
+    setMessages(historyData.messages.map(historyToMessage))
+  }, [historyData])
+
+  useEffect(() => {
+    if (!roomInfo?.isActive || !roomInfo?.id) return
+
     const wsBaseUrl = import.meta.env?.VITE_WS_BASE_URL
     if (!wsBaseUrl) return
 
+    const roomId = roomInfo.id
     const httpUrl = wsBaseUrl.replace('ws://', 'http://').replace('wss://', 'https://')
     const token = localStorage.getItem('accessToken') ?? ''
 
     try {
       const client = new Client({
         webSocketFactory: () => new SockJS(httpUrl),
-        connectHeaders: {
-          Authorization: `Bearer ${token}`,
-        },
+        connectHeaders: { Authorization: `Bearer ${token}` },
         reconnectDelay: 5000,
         heartbeatIncoming: 4000,
         heartbeatOutgoing: 4000,
@@ -116,25 +97,40 @@ export function LiveChatPage() {
 
       client.onConnect = () => {
         setIsConnected(true)
-        client.subscribe('/topic/chat/1', (message) => {
+        client.subscribe(`/topic/chat/${roomId}`, (message) => {
           try {
             const data = JSON.parse(message.body)
+
             if (data.type === 'PARTICIPANT_COUNT') {
               setParticipantCount(data.payload.count)
             }
+
             if (data.type === 'NEW_MESSAGE') {
               const payload = data.payload
-              const isOfficial = payload.nickname.includes('공식')
+              const isOfficial = payload.nickname?.includes('공식') ?? false
               const newMessage: Message = {
-                id: Date.now(),
+                id: payload.messageId ?? Date.now(),
                 user: payload.nickname,
                 text: payload.content,
                 avatarType: isOfficial ? 'seller' : 'bear',
                 avatarVariant: isOfficial ? 1 : getVariantFromNickname(payload.nickname),
                 isOfficial,
-                timestamp: new Date(payload.sentAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+                timestamp: new Date(payload.sentAt).toLocaleTimeString('ko-KR', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                }),
               }
               setMessages((prev) => [...prev, newMessage])
+            }
+
+            if (data.type === 'ROOM_CLOSED') {
+              setIsRoomClosed(true)
+              setIsConnected(false)
+            }
+
+            if (data.type === 'RATE_LIMIT') {
+              setIsCooldown(true)
+              setTimeout(() => setIsCooldown(false), THROTTLE_MS)
             }
           } catch {
             // ignore malformed WS frames
@@ -142,13 +138,8 @@ export function LiveChatPage() {
         })
       }
 
-      client.onDisconnect = () => {
-        setIsConnected(false)
-      }
-
-      client.onStompError = () => {
-        setIsConnected(false)
-      }
+      client.onDisconnect = () => setIsConnected(false)
+      client.onStompError = () => setIsConnected(false)
 
       client.activate()
       stompClient.current = client
@@ -159,64 +150,67 @@ export function LiveChatPage() {
     return () => {
       stompClient.current?.deactivate()
     }
-  }, [])
+  }, [roomInfo?.id, roomInfo?.isActive])
 
   useEffect(() => {
     if (scrollRef.current) {
-      scrollRef.current.scrollTo({
-        top: scrollRef.current.scrollHeight,
-        behavior: 'smooth',
-      })
+      scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
     }
   }, [messages])
 
-  const handleSend = useCallback((e: React.FormEvent) => {
-    e.preventDefault()
-    if (!inputText.trim()) return
+  const handleSend = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!inputText.trim() || isRoomClosed) return
 
-    const now = Date.now()
-    if (now - lastSendTimeRef.current < THROTTLE_MS) return
-    lastSendTimeRef.current = now
+      const now = Date.now()
+      if (now - lastSendTimeRef.current < THROTTLE_MS) return
+      lastSendTimeRef.current = now
 
-    if (stompClient.current?.connected) {
-      stompClient.current.publish({
-        destination: '/app/chat/1',
-        body: JSON.stringify({
-          type: 'SEND_MESSAGE',
-          payload: { content: inputText },
-        }),
-      })
-    } else {
-      // WS 미연결 시 로컬 업데이트 (데모/오프라인 백업)
-      const newMessage: Message = {
-        id: Date.now(),
-        user: '나',
-        text: inputText,
-        avatarType: 'human',
-        avatarVariant: 1,
-        timestamp: new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+      if (stompClient.current?.connected && roomInfo?.id) {
+        stompClient.current.publish({
+          destination: `/app/chat/${roomInfo.id}`,
+          body: JSON.stringify({ type: 'SEND_MESSAGE', payload: { content: inputText } }),
+        })
+      } else {
+        const newMessage: Message = {
+          id: Date.now(),
+          user: '나',
+          text: inputText,
+          avatarType: 'human',
+          avatarVariant: 1,
+          timestamp: new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+        }
+        setMessages((prev) => [...prev, newMessage])
       }
-      setMessages((prev) => [...prev, newMessage])
-    }
 
-    setInputText('')
-    setIsCooldown(true)
-    setTimeout(() => setIsCooldown(false), THROTTLE_MS)
-  }, [inputText])
+      setInputText('')
+      setIsCooldown(true)
+      setTimeout(() => setIsCooldown(false), THROTTLE_MS)
+    },
+    [inputText, isRoomClosed, roomInfo?.id],
+  )
+
+  if (isRoomLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-white">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-point border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (isRoomError || !roomInfo?.isActive) {
+    return <InactiveRoomScreen />
+  }
 
   return (
     <div className="relative flex flex-1 flex-col bg-white overflow-hidden min-h-0">
-      {/* 0. Subtle Background Logo Watermark - Figma 디자인 명세 100% 동기화 */}
+      {/* 0. Background Watermark */}
       <div className="absolute inset-0 z-0 flex items-center justify-center pointer-events-none overflow-hidden opacity-[0.20]">
-        <img
-          src="/logo.svg"
-          alt="My Fave Watermark"
-          className="w-[50%] h-auto grayscale"
-          style={{ imageRendering: 'auto' }}
-        />
+        <img src="/logo.svg" alt="My Fave Watermark" className="w-[50%] h-auto grayscale" style={{ imageRendering: 'auto' }} />
       </div>
 
-      {/* 1. Header Notice Card - Figma Node 99:267 (#E4DFE7, 24px) */}
+      {/* 1. Header Notice Card */}
       <div className="relative z-20 px-[20px] pt-[32px] pb-[16px]">
         <div className={`relative rounded-[24px] bg-sub1 transition-all duration-300 ${isNoticeOpen ? 'p-[24px]' : 'py-[14px] px-[24px]'}`}>
           <div className={`overflow-hidden transition-all duration-300 ${isNoticeOpen ? 'max-h-[100px] opacity-100' : 'max-h-[20px] opacity-100'}`}>
@@ -225,19 +219,23 @@ export function LiveChatPage() {
               {isNoticeOpen && (
                 <>
                   <br />
-                  <span className="font-normal opacity-90">오픈 30분 전, 지금이 찬스!<br />
-                  셀러에게 직접 물어보고 쇼핑 준비 완료하세요🎀</span>
+                  <span className="font-normal opacity-90">
+                    오픈 30분 전, 지금이 찬스!
+                    <br />
+                    셀러에게 직접 물어보고 쇼핑 준비 완료하세요🎀
+                  </span>
                 </>
               )}
             </p>
           </div>
-          <button 
+          <button
             onClick={() => setIsNoticeOpen(!isNoticeOpen)}
             className="absolute right-4 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full hover:bg-black/5 active:scale-90 transition-all"
-            aria-label={isNoticeOpen ? "공지 접기" : "공지 펴기"}
+            aria-label={isNoticeOpen ? '공지 접기' : '공지 펴기'}
           >
-            <svg 
-              width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+            <svg
+              width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
               className={`transition-transform duration-300 ${isNoticeOpen ? 'rotate-180' : 'rotate-0'}`}
             >
               <polyline points="6 9 12 15 18 9" />
@@ -261,20 +259,12 @@ export function LiveChatPage() {
         </div>
       </div>
 
-      {/* 3. Chat Messages Area - Spacing 17px & Bubble Colors 100% Match */}
-      <div 
-        ref={scrollRef}
-        className="relative z-10 flex-1 overflow-y-auto px-[19.99px] pb-[100px] scrollbar-hide"
-      >
+      {/* 3. Chat Messages Area */}
+      <div ref={scrollRef} className="relative z-10 flex-1 overflow-y-auto px-[19.99px] pb-[100px] scrollbar-hide">
         <div className="flex flex-col gap-[17px]">
           {messages.map((msg) => (
             <div key={msg.id} className={`flex items-start gap-[8.5px] ${msg.isOfficial ? 'flex-row-reverse' : ''}`}>
-              <UserIcon 
-                type={msg.avatarType} 
-                variant={msg.avatarVariant}
-                size={23.17} 
-                className="flex-shrink-0 mt-[1px]" 
-              />
+              <UserIcon type={msg.avatarType} variant={msg.avatarVariant} size={23.17} className="flex-shrink-0 mt-[1px]" />
               <div className={`flex flex-col gap-[4.5px] ${msg.isOfficial ? 'items-end' : ''}`}>
                 <div className="flex items-center gap-[6px] px-[2px]">
                   <span className={`font-noto text-[12px] leading-[18px] text-[#000000] ${msg.isOfficial ? 'font-bold' : 'font-normal'}`}>
@@ -282,10 +272,10 @@ export function LiveChatPage() {
                   </span>
                 </div>
                 <div className="flex items-end gap-[8px] max-w-[240px]">
-                  <div 
+                  <div
                     className={`rounded-[15.5px] px-[16px] py-[9.5px] shadow-sm border border-separator/5 ${
                       msg.isOfficial
-                        ? 'rounded-tr-none bg-main-bg text-[#000000] font-medium shadow-md shadow-main-bg/10' 
+                        ? 'rounded-tr-none bg-main-bg text-[#000000] font-medium shadow-md shadow-main-bg/10'
                         : 'rounded-tl-none bg-main-bg text-[rgba(0,0,0,0.9)] font-medium shadow-md shadow-main-bg/10'
                     }`}
                   >
@@ -303,28 +293,32 @@ export function LiveChatPage() {
         </div>
       </div>
 
-      {/* 4. Floating Input & Send Button - Figma Rectangle 8 & 9 (x:14, y:766) 명세 100% 동기화 */}
+      {/* 4. Input Area */}
       <div className="absolute bottom-[47px] left-0 right-0 z-30 px-[14px]">
-        <form onSubmit={handleSend} className="flex items-center gap-[8px]">
-          {/* Input Box - Figma Rectangle 8 */}
-          <div className="flex-1 h-[39px]">
-            <input
-              type="text"
-              value={inputText}
-              onChange={(e) => setInputText(e.target.value)}
-              placeholder="무엇이든 물어보세요!"
-              className="w-full h-full rounded-[21px] border border-separator bg-[#FAFAF8] px-[23px] font-noto text-[12px] text-[#000000] placeholder:text-[#B8B8B8] focus:border-point focus:outline-none transition-colors shadow-inner"
-            />
+        {isRoomClosed ? (
+          <div className="flex h-[39px] items-center justify-center rounded-[21px] bg-sub1 border border-separator">
+            <p className="font-noto text-[12px] text-muted-text">채팅방이 종료되었습니다</p>
           </div>
-          {/* Send Button - Figma Rectangle 9 */}
-          <button
-            type="submit"
-            disabled={!inputText.trim() || isCooldown}
-            className="flex h-[39px] w-[73px] items-center justify-center rounded-[21px] bg-point font-noto text-[12px] font-bold text-white shadow-lg shadow-point/20 transition-all hover:bg-[#ff7fa3] active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isCooldown ? '대기중' : '보내기'}
-          </button>
-        </form>
+        ) : (
+          <form onSubmit={handleSend} className="flex items-center gap-[8px]">
+            <div className="flex-1 h-[39px]">
+              <input
+                type="text"
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder="무엇이든 물어보세요!"
+                className="w-full h-full rounded-[21px] border border-separator bg-[#FAFAF8] px-[23px] font-noto text-[12px] text-[#000000] placeholder:text-[#B8B8B8] focus:border-point focus:outline-none transition-colors shadow-inner"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={!inputText.trim() || isCooldown}
+              className="flex h-[39px] w-[73px] items-center justify-center rounded-[21px] bg-point font-noto text-[12px] font-bold text-white shadow-lg shadow-point/20 transition-all hover:bg-[#ff7fa3] active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isCooldown ? '대기중' : '보내기'}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/shared/components/LiveChatPreview.tsx
+++ b/frontend/src/shared/components/LiveChatPreview.tsx
@@ -1,91 +1,94 @@
 import { Link } from 'react-router-dom'
-
 import { UserIcon } from '@/shared/components/UserIcon'
+import { useChatPreview } from '@/features/chat/hooks'
 
-interface ChatMessage {
-  user: string
-  text: string
-  avatarType: 'bear' | 'human' | 'seller'
-  avatarVariant: number
-  isOfficial?: boolean
-  align?: 'left' | 'right'
+function getVariantFromNickname(nickname: string): number {
+  const BEAR_VARIANTS = [1, 3, 5, 6, 7, 10] as const
+  let hash = 0
+  for (let i = 0; i < nickname.length; i++) {
+    hash = (hash + nickname.charCodeAt(i)) % BEAR_VARIANTS.length
+  }
+  return BEAR_VARIANTS[hash]
 }
 
-const chatMessages: ChatMessage[] = [
-  {
-    user: '복숭아맛구름',
-    text: '드디어 오늘이다 ㅠㅠ 언니 트위드 자켓 기다렸어요!',
-    avatarType: 'bear',
-    avatarVariant: 5,
-  },
-  {
-    user: '민트초코는진리',
-    text: '혹시 니트 카디건 사이즈 프리인가요??',
-    avatarType: 'bear',
-    avatarVariant: 3,
-  },
-  {
-    user: 'My Fave 공식',
-    text: '네! 앙고라 니트 카디건 사이즈 프리이고 40% 세일 중입니다💕 판매 시작되면 바로 확인해주세요!',
-    avatarType: 'seller',
-    avatarVariant: 1,
-    isOfficial: true,
-    align: 'right',
-  },
-  {
-    user: '라벤더무드',
-    text: '10분 전에 알림 한번 더 와주면 좋겠다!',
-    avatarType: 'bear',
-    avatarVariant: 7,
-  },
-]
-
 export function LiveChatPreview() {
+  const { data, isLoading, isError } = useChatPreview(5)
+
+  if (isLoading) {
+    return (
+      <div className="rounded-[5px] border border-main-bg bg-main-bg p-[20px] shadow-sm">
+        <div className="mb-[16px] flex items-center justify-between px-[2px]">
+          <h3 className="font-noto text-[14px] font-bold text-dark-text tracking-tight">라이브 톡</h3>
+          <div className="h-4 w-12 rounded bg-gray-200 animate-pulse" />
+        </div>
+        <div className="space-y-[16px]">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-start gap-[8px]">
+              <div className="h-6 w-6 rounded-full bg-gray-200 animate-pulse flex-shrink-0" />
+              <div className="flex flex-col gap-2">
+                <div className="h-3 w-16 rounded bg-gray-200 animate-pulse" />
+                <div className="h-8 w-40 rounded-[15.5px] bg-gray-200 animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-[20px] h-[46px] w-full rounded-[5px] bg-gray-200 animate-pulse" />
+      </div>
+    )
+  }
+
+  const isActive = !isError && data?.isActive === true
+  const messages = data?.recentMessages ?? []
+
   return (
     <div className="rounded-[5px] border border-main-bg bg-main-bg p-[20px] shadow-sm">
       <div className="mb-[16px] flex items-center justify-between px-[2px]">
         <h3 className="font-noto text-[14px] font-bold text-dark-text tracking-tight">라이브 톡</h3>
-        <span className="flex items-center gap-1 font-noto text-[10px] text-point">
-          <span className="h-1.5 w-1.5 rounded-full bg-point animate-pulse" />
-          실시간
-        </span>
-      </div>
-      <div className="space-y-[16px]">
-        {chatMessages.map((msg, i) => (
-          <div
-            key={i}
-            className={`flex items-start gap-[8px] ${msg.align === 'right' ? 'flex-row-reverse' : ''}`}
-          >
-            <UserIcon
-              type={msg.avatarType}
-              variant={msg.avatarVariant}
-              size={23.17}
-              className="flex-shrink-0"
-            />
-            <div className={`flex flex-col gap-[4px] ${msg.align === 'right' ? 'items-end' : ''}`}>
-              <span className="font-noto text-[12px] font-normal leading-[18px] text-dark-text/70">
-                {msg.user}
-                {msg.isOfficial && (
-                  <span className="ml-1 rounded bg-point px-1.5 py-0.5 text-[8px] font-black text-white">
-                    공식
-                  </span>
-                )}
-              </span>
-              <div
-                className={`max-w-[210px] rounded-[15.5px] px-[16px] py-[10px] ${
-                  msg.align === 'right'
-                    ? 'rounded-tr-none bg-point text-white shadow-sm'
-                    : 'rounded-tl-none bg-chat-bg2 text-chat-font2 shadow-sm'
-                }`}
-              >
-                <p className="font-noto text-[12px] leading-[18.2px] font-normal tracking-tight">{msg.text}</p>
-              </div>
-            </div>
-          </div>
-        ))}
+        {isActive ? (
+          <span className="flex items-center gap-1 font-noto text-[10px] text-point">
+            <span className="h-1.5 w-1.5 rounded-full bg-point animate-pulse" />
+            실시간
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 font-noto text-[10px] text-muted-text">
+            <span className="h-1.5 w-1.5 rounded-full bg-gray-400" />
+            준비중
+          </span>
+        )}
       </div>
 
-      <Link 
+      {messages.length > 0 ? (
+        <div className="space-y-[16px]">
+          {messages.map((msg, i) => (
+            <div key={i} className="flex items-start gap-[8px]">
+              <UserIcon
+                type="bear"
+                variant={getVariantFromNickname(msg.senderNickname)}
+                size={23.17}
+                className="flex-shrink-0"
+              />
+              <div className="flex flex-col gap-[4px]">
+                <span className="font-noto text-[12px] font-normal leading-[18px] text-dark-text/70">
+                  {msg.senderNickname}
+                </span>
+                <div className="max-w-[210px] rounded-[15.5px] rounded-tl-none bg-chat-bg2 px-[16px] py-[10px] shadow-sm">
+                  <p className="font-noto text-[12px] leading-[18.2px] font-normal tracking-tight text-chat-font2">
+                    {msg.content}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center justify-center py-6">
+          <p className="font-noto text-[12px] text-muted-text">
+            {isActive ? '아직 메시지가 없습니다' : '채팅방이 곧 활성화 됩니다'}
+          </p>
+        </div>
+      )}
+
+      <Link
         to="/live-chat"
         className="mt-[20px] flex h-[46px] w-full items-center justify-center rounded-[5px] bg-point font-montserrat text-[14px] font-semibold text-chat-bg shadow-lg shadow-point/20 transition-all hover:bg-[#ff7fa3] active:scale-[0.98]"
       >


### PR DESCRIPTION
## 📌 관련 이슈
Closes #94

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
채팅방 정보 조회
메시지 히스토리
채팅방 종료
채팅방 미리보기

임시 채팅방 오픈(테스트용)
  - POST /api/v1/chat-room/opentemp 엔드포인트 추가
  - SecurityConfig에서 해당 경로 권한 검사 제외 처리
## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 API 엔드포인트 경로가 `/chat`에서 `/chat-room`으로 변경되었습니다.
  * 채팅방 정보 조회, 메시지 히스토리(페이지네이션 및 커서 지원), 채팅 미리보기, 임시 채팅방 개설, 채팅방 종료 기능이 추가되었습니다.
  * 일부 채팅 기능에 대해 인증 요구 사항이 적용되었습니다.

* **테스트**
  * 채팅 기능에 대한 포괄적인 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->