### PR TITLE
Config: [SecurityConfig.java] JWT 인증 활성화 및 공개 엔드포인트 화이트리스트 추가

### DIFF
--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -31,13 +32,22 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // 인증·문서·웹훅 등 시스템 경로 (JWT 면제)
                         .requestMatchers(
-                                "/auth/**",        // context-path(/api/v1) 제외한 경로로 매칭
+                                "/auth/**",            // context-path(/api/v1) 제외한 경로로 매칭
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/ws/**"
+                                "/ws/**",
+                                "/payments/webhook"    // 외부 PG(PortOne) 콜백 - HMAC 서명으로 자체 보안
                         ).permitAll()
-                        .anyRequest().permitAll()   // (JWT 인증 필요).anyRequest().authenticated() ㅣ (JWT 없이 모든 요청 허용) .anyRequest().permitAll()
+                        // 비로그인 공개 조회 (카탈로그·콘텐츠·이벤트)
+                        .requestMatchers(HttpMethod.GET,
+                                "/products/**",
+                                "/content/short-forms",
+                                "/content/style-feeds",
+                                "/sale-events/current"
+                        ).permitAll()
+                        .anyRequest().authenticated()  // 그 외 모든 요청은 JWT 인증 필수
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 📌 관련 이슈
Closes #이슈번호

## 📝 작업 내용
- .anyRequest().permitAll() → .anyRequest().authenticated() 전환
- /payments/webhook 화이트리스트 추가 (PortOne 콜백 - HMAC 서명 검증)
- GET 공개 경로 화이트리스트: /products/**, /content/short-forms, /content/style-feeds, /sale-events/current (비로그인 카탈로그 조회 허용)

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **API 보안 강화**
  * 대부분의 API 엔드포인트에 대한 인증 요구 사항 강화
  * 카탈로그 조회, 인증, 결제 웹훅 엔드포인트는 인증 없이 접근 가능하도록 유지

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->