### PR TITLE
refactor: Shipping 컨트롤러 JWT 인증 대응 (#119)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/controller/ShippingController.java
@@ -1,27 +1,20 @@
 package com.myfave.api.domain.shipping.controller;
 
 import com.myfave.api.domain.shipping.service.ShippingService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.myfave.api.domain.shipping.dto.request.ShippingAddressRequest;
+import com.myfave.api.domain.shipping.dto.response.DefaultAddressResponse;
 import com.myfave.api.domain.shipping.dto.response.ShippingAddressResponse;
 import com.myfave.api.global.common.ApiResponse;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import com.myfave.api.domain.shipping.dto.request.ShippingAddressRequest;
-import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
-import com.myfave.api.domain.shipping.dto.response.DefaultAddressResponse;
-import org.springframework.web.bind.annotation.PatchMapping;
 
 @RestController
 @RequestMapping("/shipping")
@@ -30,9 +23,10 @@ public class ShippingController {
 
     private final ShippingService shippingService;
 
+    // 7-1. 배송지 목록 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ShippingAddressResponse>>> getShippingAddresses() {
-        Long userId = 1L;
+    public ResponseEntity<ApiResponse<List<ShippingAddressResponse>>> getShippingAddresses(
+            @AuthenticationPrincipal Long userId) {
         List<ShippingAddressResponse> response = shippingService.getShippingAddresses(userId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
@@ -40,8 +34,8 @@ public class ShippingController {
     // 7-2. 배송지 추가
     @PostMapping
     public ResponseEntity<ApiResponse<ShippingAddressResponse>> addShippingAddress(
+            @AuthenticationPrincipal Long userId,
             @RequestBody @Valid ShippingAddressRequest request) {
-        Long userId = 1L;
         ShippingAddressResponse response = shippingService.addShippingAddress(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("배송지가 등록되었습니다.", response));
@@ -50,8 +44,8 @@ public class ShippingController {
     // 7-3. 배송지 삭제
     @DeleteMapping("/{addressId}")
     public ResponseEntity<ApiResponse<Void>> deleteShippingAddress(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long addressId) {
-        Long userId = 1L;
         shippingService.deleteShippingAddress(userId, addressId);
         return ResponseEntity.ok(ApiResponse.ok("배송지가 삭제되었습니다."));
     }
@@ -59,8 +53,8 @@ public class ShippingController {
     // 7-4. 기본 배송지 설정
     @PatchMapping("/{addressId}/default")
     public ResponseEntity<ApiResponse<DefaultAddressResponse>> setDefaultAddress(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long addressId) {
-        Long userId = 1L;
         DefaultAddressResponse response = shippingService.setDefaultAddress(userId, addressId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }


### PR DESCRIPTION
- 4개 엔드포인트 모두 `Long userId = 1L` 하드코딩 제거
- `@AuthenticationPrincipal Long userId`로 교체

## 📌 관련 이슈
Closes #119 

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)
