### PR TITLE
refactor: Content 컨트롤러/서비스 JWT 인증 대응 (#120)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
@@ -1,10 +1,6 @@
 package com.myfave.api.domain.content.controller;
 
 import com.myfave.api.domain.content.service.ContentService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.myfave.api.domain.content.dto.request.ContentRegisterRequest;
 import com.myfave.api.domain.content.dto.response.ContentRegisterResponse;
 import com.myfave.api.domain.content.dto.response.StyleFeedResponse;
@@ -14,15 +10,14 @@ import com.myfave.api.global.common.ApiResponse;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -56,11 +51,11 @@ public class ContentController {
     // 9-3. 콘텐츠 등록 (Influencer)
     @PostMapping
     public ResponseEntity<ApiResponse<ContentRegisterResponse>> registerContent(
+            @AuthenticationPrincipal Long userId,
             @Valid @ModelAttribute ContentRegisterRequest request,
             @RequestParam("mediaFile") MultipartFile mediaFile,
             @RequestParam(value = "thumbnailFile", required = false) MultipartFile thumbnailFile) {
-
-        ContentRegisterResponse response = contentService.registerContent(request, mediaFile, thumbnailFile);
+        ContentRegisterResponse response = contentService.registerContent(userId, request, mediaFile, thumbnailFile);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("콘텐츠가 등록되었습니다.", response));
     }

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -15,6 +15,8 @@ import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import com.myfave.api.global.util.S3UploadService;
 
+import org.springframework.beans.factory.annotation.Value;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -36,6 +38,9 @@ public class ContentService {
     private final StyleFeedRepository styleFeedRepository;
     private final ProductRepository productRepository;
     private final S3UploadService s3UploadService;
+
+    @Value("${influencer.user-id}")
+    private Long influencerUserId;
 
     // 9-1. 숏폼 목록 조회
     public List<ShortFormResponse> getShortForms(ShortFormType type, int size) {
@@ -66,9 +71,15 @@ public class ContentService {
     // 9-3. 콘텐츠 등록
     @Transactional
     public ContentRegisterResponse registerContent(
+            Long userId,
             ContentRegisterRequest request,
             MultipartFile mediaFile,
             MultipartFile thumbnailFile) {
+
+        // 0. 인플루언서 권한 검증
+        if (!influencerUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
 
         // 1. 상품 조회 (soft-delete된 상품 제외)
         Product product = productRepository.findByProductIdAndDeletedAtIsNull(request.getProductId())


### PR DESCRIPTION
- POST /content에 `@AuthenticationPrincipal Long userId` 추가
- ContentService.registerContent 시그니처에 userId 파라미터 추가
- 인플루언서 권한 검증 추가 (CouponService 패턴 동일)

## 📌 관련 이슈
Closes #120 

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)
