### PR TITLE
refactor: User 컨트롤러 JWT 인증 대응 (#121)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
@@ -26,7 +26,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserResponse>> getUser(
             @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId) {
-        if (!currentUserId.equals(userId)) {
+        if (!userId.equals(userId)) {
             throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
         }
         UserResponse response = userService.getUser(userId);
@@ -39,7 +39,7 @@ public class UserController {
             @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId,
             @RequestBody @Valid UserUpdateRequest request) {
-        if (!currentUserId.equals(userId)) {
+        if (!userId.equals(userId)) {
             throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
         }
         UserResponse response = userService.updateUser(userId, request);

--- a/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
@@ -1,13 +1,18 @@
 package com.myfave.api.domain.user.controller;
 
+import com.myfave.api.domain.user.dto.request.UserUpdateRequest;
 import com.myfave.api.domain.user.dto.response.UserResponse;
 import com.myfave.api.domain.user.service.UserService;
 import com.myfave.api.global.common.ApiResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import com.myfave.api.domain.user.dto.request.UserUpdateRequest;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -16,19 +21,27 @@ public class UserController {
 
     private final UserService userService;
 
+    // 2-1. 회원 정보 조회 (본인만)
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse<UserResponse>> getUser(
+            @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId) {
-
+        if (!currentUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
         UserResponse response = userService.getUser(userId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    // 2-2. 회원 정보 수정 (본인만)
     @PatchMapping("/{userId}/edit")
     public ResponseEntity<ApiResponse<UserResponse>> updateUser(
+            @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId,
             @RequestBody @Valid UserUpdateRequest request) {
-
+        if (!currentUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
         UserResponse response = userService.updateUser(userId, request);
         return ResponseEntity.ok(
                 new ApiResponse<>(200, "회원 정보가 수정되었습니다.", response));

--- a/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/myfave/api/domain/user/controller/UserController.java
@@ -26,7 +26,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserResponse>> getUser(
             @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId) {
-        if (!userId.equals(userId)) {
+        if (!userId.equals(currentUserId)) {
             throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
         }
         UserResponse response = userService.getUser(userId);
@@ -39,7 +39,7 @@ public class UserController {
             @AuthenticationPrincipal Long currentUserId,
             @PathVariable Long userId,
             @RequestBody @Valid UserUpdateRequest request) {
-        if (!userId.equals(userId)) {
+        if (!userId.equals(currentUserId)) {
             throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
         }
         UserResponse response = userService.updateUser(userId, request);


### PR DESCRIPTION
- GET /users/{userId}: `@AuthenticationPrincipal` 추가 + 본인 확인 검증
- PATCH /users/{userId}/edit: `@AuthenticationPrincipal` 추가 + 본인 확인 검증

## 📌 관련 이슈
Closes #121 

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자 프로필 조회 및 수정 엔드포인트에 인증 주체를 도입해 로그인 사용자에 대한 접근 제어를 시도했습니다. 의도는 본인만 조회/수정 가능하도록 차단하는 것이었으나, 현재 권한 검사 로직에 오류가 있어 실제 차단이 적용되지 않습니다(수정 필요).

* **Chores**
  * 인증 및 오류 처리 관련 항목을 정비했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->