### PR TITLE
refactor:JWT 인증 대응(Product, coupon, saleEvent)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/coupon/controller/CouponController.java
+++ b/backend/src/main/java/com/myfave/api/domain/coupon/controller/CouponController.java
@@ -10,10 +10,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,30 +30,16 @@ public class CouponController {
     // 8-1. 보유 쿠폰 목록 조회
     @GetMapping
     public ResponseEntity<ApiResponse<List<CouponResponse>>> getMyCoupons(
+            @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) CouponStatus status) {
-        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
-        Long userId = 1L;
         List<CouponResponse> response = couponService.getMyCoupons(userId, status);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    /**
-     * 8-2. 사용자 쿠폰 지급 (인플루언서 전용)
-     *
-     * TODO [Sprint 4 JWT 활성화 시 필수 교체]
-     *  - @RequestHeader("X-User-Id") Long requesterId
-     *    → @AuthenticationPrincipal UserDetailsImpl userDetails 로 교체
-     *  - 메서드 본문: Long requesterId = userDetails.getUserId();
-     *
-     *  [왜 지금 헤더 방식?]
-     *  8-2는 인플루언서 권한 체크가 핵심 비즈니스 로직이라,
-     *  JWT 복구 전까지 X-User-Id 헤더로 요청자 ID를 임시 전달받아 권한 체크 검증.
-     *  (다른 도메인은 userId=1L 하드코딩이지만, 이 API는 권한 체크를 실제 테스트 가능하게
-     *   변동 가능한 입력 소스로 받음. 서비스 레이어 권한 체크 로직은 JWT 복구 후에도 그대로 유지.)
-     */
+    // 8-2. 사용자 쿠폰 지급 (인플루언서 전용)
     @PostMapping
     public ResponseEntity<ApiResponse<CouponIssueResponse>> issueCoupon(
-            @RequestHeader("X-User-Id") Long requesterId,
+            @AuthenticationPrincipal Long requesterId,
             @RequestBody @Valid CouponIssueRequest request) {
         CouponIssueResponse response = couponService.issueCoupon(requesterId, request);
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -50,13 +51,12 @@ public class ProductController {
     // 3-3. 상품 등록 (인플루언서 전용)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE) //이미지 파일 같이 받아야해서 일반 json 불가
     public ResponseEntity<ApiResponse<Map<String, Long>>> createProduct(
+            @AuthenticationPrincipal Long userId,
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                     schema = @Schema(implementation = ProductRequest.class)))
             @RequestPart @Valid ProductRequest request,
             //이미지 파일 목록
             @RequestPart List<MultipartFile> images) {
-        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
-        Long userId = 1L;
         Long productId = productService.createProduct(userId, request, images);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("Created", Map.of("id", productId)));
@@ -65,31 +65,30 @@ public class ProductController {
     // 3-4. 상품 수정 (인플루언서 전용)
     @PatchMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Map<String, Long>>> updateProduct(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long productId,
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                     schema = @Schema(implementation = ProductUpdateRequest.class)))
             @RequestPart(required = false) @Valid ProductUpdateRequest request,
             @RequestPart(required = false) List<MultipartFile> images) {
-        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
-        Long userId = 1L;
         Long updatedId = productService.updateProduct(userId, productId, request, images);
         return ResponseEntity.ok(ApiResponse.ok(Map.of("id", updatedId)));
     }
 
     // 3-5. 상품 삭제 (인플루언서 전용, Soft Delete)
     @DeleteMapping("/{productId}")
-    public ResponseEntity<ApiResponse<Void>> deleteProduct(@PathVariable Long productId) {
-        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
-        Long userId = 1L;
+    public ResponseEntity<ApiResponse<Void>> deleteProduct(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long productId) {
         productService.deleteProduct(userId, productId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     // 3-6. 품절 처리 (인플루언서 전용)
     @PatchMapping("/{productId}/soldout")
-    public ResponseEntity<ApiResponse<Void>> markAsSoldout(@PathVariable Long productId) {
-        // TODO: JWT에서 userId 가져오기 (지금은 임시로 1L)
-        Long userId = 1L;
+    public ResponseEntity<ApiResponse<Void>> markAsSoldout(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long productId) {
         productService.markAsSoldout(userId, productId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }

--- a/backend/src/main/java/com/myfave/api/domain/saleevent/controller/SaleEventController.java
+++ b/backend/src/main/java/com/myfave/api/domain/saleevent/controller/SaleEventController.java
@@ -8,6 +8,7 @@ import com.myfave.api.domain.saleevent.dto.response.SaleEventUpdateResponse;
 import com.myfave.api.domain.saleevent.service.SaleEventService;
 import com.myfave.api.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,15 +23,18 @@ public class SaleEventController {
         return ApiResponse.ok(saleEventService.getCurrentEvent());
     }
 
-    @PostMapping //이벤트 등록
-    public ApiResponse<SaleEventCreateResponse> createEvent(@RequestBody SaleEventCreateRequest request) { //JSON → Request DTO
-        return ApiResponse.created("판매 이벤트가 등록되었습니다.", saleEventService.createEvent(request));
+    @PostMapping //이벤트 등록 (인플루언서 전용)
+    public ApiResponse<SaleEventCreateResponse> createEvent(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody SaleEventCreateRequest request) { //JSON → Request DTO
+        return ApiResponse.created("판매 이벤트가 등록되었습니다.", saleEventService.createEvent(userId, request));
     }
 
-    @PatchMapping("/{saleId}") //이벤트 수정
+    @PatchMapping("/{saleId}") //이벤트 수정 (인플루언서 전용)
     public ApiResponse<SaleEventUpdateResponse> updateEvent(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long saleId,                      // URL에서 saleId 추출
             @RequestBody SaleEventUpdateRequest request) {  // JSON → Request DTO
-        return ApiResponse.ok(saleEventService.updateEvent(saleId, request));
+        return ApiResponse.ok(saleEventService.updateEvent(userId, saleId, request));
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/saleevent/service/SaleEventService.java
+++ b/backend/src/main/java/com/myfave/api/domain/saleevent/service/SaleEventService.java
@@ -10,6 +10,7 @@ import com.myfave.api.domain.saleevent.repository.SaleEventRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,9 @@ import java.util.Optional;
 public class SaleEventService {
 
     private final SaleEventRepository saleEventRepository;
+
+    @Value("${influencer.user-id}")
+    private Long influencerUserId;
     //이벤트 조회
     public SaleEventResponse getCurrentEvent() {
         ZonedDateTime now = ZonedDateTime.now();
@@ -42,9 +46,14 @@ public class SaleEventService {
         // 3단계: 둘 다 없으면 404 에러
         throw new CustomException(ErrorCode.SALE_EVENT_NOT_FOUND);
     }
-    //이벤트 등록
+    //이벤트 등록 (인플루언서 전용)
     @Transactional //DB에 써야하니까 트랜잭션 처리
-    public SaleEventCreateResponse createEvent(SaleEventCreateRequest request) {
+    public SaleEventCreateResponse createEvent(Long userId, SaleEventCreateRequest request) {
+        // 인플루언서 권한 체크
+        if (!influencerUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
         // 검증 1 : 종료시간이 시작시간보다 뒤인지
         if (!request.getSaleEndAt().isAfter(request.getSaleStartAt())) {
             throw new CustomException(ErrorCode.COMMON_INVALID_INPUT);
@@ -64,9 +73,14 @@ public class SaleEventService {
         SaleEvent saved = saleEventRepository.save(saleEvent);
         return SaleEventCreateResponse.from(saved);
     }
-    //이벤트 수정
+    //이벤트 수정 (인플루언서 전용)
     @Transactional
-    public SaleEventUpdateResponse updateEvent(Long saleId, SaleEventUpdateRequest request) {
+    public SaleEventUpdateResponse updateEvent(Long userId, Long saleId, SaleEventUpdateRequest request) {
+        // 인플루언서 권한 체크
+        if (!influencerUserId.equals(userId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
         // 해당 이벤트가 DB에 있는지 확인, 없으면 404
         SaleEvent saleEvent = saleEventRepository.findById(saleId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SALE_EVENT_NOT_FOUND));


### PR DESCRIPTION
## 📌 관련 이슈
Closes #129 

## 📝 작업 내용
`anyRequest().authenticated()` 전환에 맞춰 본인 담당 도메인 3개 컨트롤러 정리.                                                                                       
                                                  
  ### Coupon                                                                                                                                                           
  - 8-1 보유 쿠폰 목록 조회: `userId = 1L` 하드코딩 제거 → `@AuthenticationPrincipal`                                                                                
  - 8-2 쿠폰 지급(인플루언서 전용): 임시 `@RequestHeader("X-User-Id")` 제거 → `@AuthenticationPrincipal`                                                               
  - 서비스 레이어 인플루언서 권한 체크 로직은 그대로 유지                                                                                                            
                                                                                                                                                                       
  ### Product                                     
  - POST/PATCH/DELETE/soldout 4곳 `userId = 1L` 제거 → `@AuthenticationPrincipal`                                                                                      
  - GET 목록/상세는 SecurityConfig 화이트리스트로 비로그인 노출 유지                                                                                                 
                                                                                                                                                                       
  ### SaleEvent                                                                                                                                                      
  - POST /sale-events, PATCH /sale-events/{saleId}에 `@AuthenticationPrincipal` 추가                                                                                   
  - 서비스 시그니처에 userId 전파 + 인플루언서 권한 체크 추가 (Coupon/Content/Product와 동일 패턴)                                                                     
  - GET /sale-events/current는 화이트리스트 유지
  - 
## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
 **테스트 컴파일 시 chat 도메인에서 3건 에러가 보이는데 본 PR 변경 전부터 존재한 사전 결함입니다 (별도 공유). 메인 컴파일은 통과.**         

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 쿠폰 조회 및 발급, 상품 생성·수정·삭제 처리 시 사용자 식별 메커니즘이 개선되었습니다.
* 세일 이벤트 생성 및 수정 작업에 사용자 권한 검증 기능이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->