### PR TITLE
[FEAT] 모니터링 툴 구축

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Observability
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/ws/**",
-                                "/payments/webhook"    // 외부 PG(PortOne) 콜백 - HMAC 서명으로 자체 보안
+                                "/payments/webhook",   // 외부 PG(PortOne) 콜백 - HMAC 서명으로 자체 보안
+                                "/actuator/health",
+                                "/actuator/prometheus" // Prometheus scraper 접근 허용
                         ).permitAll()
                         // 비로그인 공개 조회 (카탈로그·콘텐츠·이벤트)
                         // /chat-room, /chat-room/preview, /chat-room/messages 는 의도적으로 공개:

--- a/backend/src/main/java/com/myfave/api/global/filter/TraceIdFilter.java
+++ b/backend/src/main/java/com/myfave/api/global/filter/TraceIdFilter.java
@@ -15,14 +15,14 @@ import java.util.UUID;
 public class TraceIdFilter extends OncePerRequestFilter {
 
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
-    private static final String MDC_KEY = "traceId";
+    private static final String MDC_KEY = "trace_id";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String traceId = request.getHeader(TRACE_ID_HEADER);
         if (traceId == null || traceId.isBlank()) {
-            traceId = UUID.randomUUID().toString();
+            traceId = UUID.randomUUID().toString().replace("-", "");
         }
         MDC.put(MDC_KEY, traceId);
         response.setHeader(TRACE_ID_HEADER, traceId);

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -73,8 +73,8 @@ portone:
     kakao-pay: ${PORTONE_CHANNEL_KEY_KAKAOPAY:local-kakao-key}
     naver-pay: ${PORTONE_CHANNEL_KEY_NAVERPAY:local-naver-key}
     toss-pay: ${PORTONE_CHANNEL_KEY_TOSSPAY:local-toss-key}
-    
- tracker:
+
+tracker:
   client-id: ${TRACKER_CLIENT_ID:local-client-id}
   client-secret: ${TRACKER_CLIENT_SECRET:local-client-secret}
   api-url: https://apis.tracker.delivery/graphql

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -79,3 +79,9 @@ tracker:
   client-secret: ${TRACKER_CLIENT_SECRET:local-client-secret}
   api-url: https://apis.tracker.delivery/graphql
   timeout-seconds: 15
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,7 +49,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, prometheus
+        include: health
   metrics:
     tags:
       application: myfave-api

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -53,8 +53,3 @@ management:
   metrics:
     tags:
       application: myfave-api
-
-# 로그 패턴에 traceId 포함 (OTel Agent가 MDC에 trace_id 주입)
-logging:
-  pattern:
-    console: "%d{HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{trace_id}] %logger{36} - %msg%n"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -43,3 +43,18 @@ tracker:
   client-secret: ${TRACKER_CLIENT_SECRET}
   api-url: https://apis.tracker.delivery/graphql
   timeout-seconds: 15
+
+# Observability
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  metrics:
+    tags:
+      application: myfave-api
+
+# 로그 패턴에 traceId 포함 (OTel Agent가 MDC에 trace_id 주입)
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{trace_id}] %logger{36} - %msg%n"

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId:-no-trace}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{trace_id:-no-trace}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{trace_id:-no-trace}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] traceId=%X{trace_id:-no-trace} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -50,11 +50,6 @@ services:
     networks:
       - myfave-network
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
 
   promtail:
     image: grafana/promtail:latest
@@ -84,12 +79,6 @@ services:
     networks:
       - myfave-network
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3200/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
 
 volumes:
   grafana-data:
@@ -98,4 +87,4 @@ volumes:
 
 networks:
   myfave-network:
-    external: true
+    driver: bridge

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,101 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: myfave-prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - "--web.enable-remote-write-receiver"
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    networks:
+      - myfave-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: myfave-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - myfave-network
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+
+  loki:
+    image: grafana/loki:latest
+    container_name: myfave-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki.yaml:/etc/loki/local-config.yaml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - myfave-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: myfave-promtail
+    volumes:
+      - ./observability/promtail.yaml:/etc/promtail/config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yaml
+    networks:
+      - myfave-network
+    restart: unless-stopped
+    depends_on:
+      - loki
+    user: root
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: myfave-tempo
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./observability/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/tmp/tempo
+    command: -config.file=/etc/tempo.yaml
+    networks:
+      - myfave-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3200/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+volumes:
+  grafana-data:
+  loki-data:
+  tempo-data:
+
+networks:
+  myfave-network:
+    external: true

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -25,7 +25,7 @@ services:
       - "3000:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set}
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -57,6 +57,7 @@ services:
     volumes:
       - ./observability/promtail.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      - promtail-data:/var/lib/promtail
     command: -config.file=/etc/promtail/config.yaml
     networks:
       - myfave-network
@@ -84,6 +85,7 @@ volumes:
   grafana-data:
   loki-data:
   tempo-data:
+  promtail-data:
 
 networks:
   myfave-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   app:
+    container_name: myfave-app
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -25,6 +26,10 @@ services:
       PORTONE_CHANNEL_KEY_KAKAOPAY: ${PORTONE_CHANNEL_KEY_KAKAOPAY}
       PORTONE_CHANNEL_KEY_NAVERPAY: ${PORTONE_CHANNEL_KEY_NAVERPAY}
       PORTONE_CHANNEL_KEY_TOSSPAY: ${PORTONE_CHANNEL_KEY_TOSSPAY}
+      OTEL_SERVICE_NAME: myfave-api
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+      OTEL_RESOURCE_ATTRIBUTES: service.name=myfave-api,deployment.environment=local
+      OTEL_LOGS_EXPORTER: none
     depends_on:
       postgres:
         condition: service_healthy
@@ -34,6 +39,7 @@ services:
       - myfave-network
 
   postgres:
+    container_name: myfave-postgres
     image: postgres:16-alpine
     ports:
       - "5432:5432"
@@ -52,6 +58,7 @@ services:
       - myfave-network
 
   redis:
+    container_name: myfave-redis
     image: redis:7-alpine
     ports:
       - "6379:6379"

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,38 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    jsonData:
+      timeInterval: "15s"
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    access: proxy
+    jsonData:
+      derivedFields:
+        - name: TraceID
+          matcherRegex: 'traceId=([a-f0-9]{32})'
+          url: "$${__value.raw}"
+          datasourceUid: tempo
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    access: proxy
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        filterByTraceID: true
+        filterBySpanID: false
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true

--- a/observability/loki.yaml
+++ b/observability/loki.yaml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'myfave-api'
+    metrics_path: '/api/v1/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080']
+    relabel_configs:
+      - target_label: application
+        replacement: myfave-api

--- a/observability/promtail.yaml
+++ b/observability/promtail.yaml
@@ -3,7 +3,7 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/observability/promtail.yaml
+++ b/observability/promtail.yaml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: name
+            values: ['myfave-app', 'myfave-postgres', 'myfave-redis']
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: 'logstream'
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'service'

--- a/observability/tempo.yaml
+++ b/observability/tempo.yaml
@@ -1,0 +1,34 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+  trace_idle_period: 10s
+
+compactor:
+  compaction:
+    compaction_window: 1h
+    max_compaction_objects: 1000000
+    block_retention: 48h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal
+
+querier:
+  frontend_worker:
+    frontend_address: 127.0.0.1:9095

--- a/observability/tempo.yaml
+++ b/observability/tempo.yaml
@@ -10,25 +10,10 @@ distributor:
         http:
           endpoint: 0.0.0.0:4318
 
-ingester:
-  max_block_bytes: 1_000_000
-  max_block_duration: 5m
-  trace_idle_period: 10s
-
-compactor:
-  compaction:
-    compaction_window: 1h
-    max_compaction_objects: 1000000
-    block_retention: 48h
-
 storage:
   trace:
     backend: local
     local:
-      path: /tmp/tempo/blocks
+      path: /var/tempo/traces
     wal:
-      path: /tmp/tempo/wal
-
-querier:
-  frontend_worker:
-    frontend_address: 127.0.0.1:9095
+      path: /var/tempo/wal


### PR DESCRIPTION
## 📌 관련 이슈
  Closes #147

  ## 📝 작업 내용
  Spring Boot 백엔드에 Prometheus(메트릭) + Grafana(시각화) + Loki(로그) + Promtail(로그 수집) + Tempo(트레이스)를
  Docker Compose로 구성하여 로컬 환경에서 완전한 Observability Stack을 운영할 수 있도록 합니다.

  ## 🔍 변경 사항
  - [x] 기능 추가

  ## 💡 구현 방법 / 주요 변경 포인트

  ### 아키텍처
  - **Metrics**: Prometheus → `/api/v1/actuator/prometheus` 15초 간격 스크랩
  - **Logs**: Promtail → Docker 소켓으로 컨테이너 로그 수집 → Loki
  - **Traces**: OTel Java Agent v2.9.0 → OTLP gRPC → Tempo
  - Grafana에서 Loki 로그의 `traceId` 필드로 Tempo 트레이스 바로 이동 가능

  ### 파일 구성
  - `docker-compose.monitoring.yml` — 5개 모니터링 서비스를 기존 `docker-compose.yml`과 분리
  - `observability/` — Prometheus, Loki, Promtail, Tempo, Grafana 설정 파일
  - `backend/Dockerfile` — OTel Java Agent 다운로드 + 3-stage 빌드 적용
  - `backend/build.gradle` — actuator + micrometer-prometheus 의존성 추가
  - `backend/src/main/resources/application.yml` — actuator 엔드포인트 노출 설정

  ## ✅ 테스트 방법
  1. 환경 설정: `.env`에 `DB_USERNAME=postgres`, `DB_PASSWORD=postgres` 확인
  2. 실행: `docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d --build`
  3. 확인 사항:
     - `http://localhost:3000` — Grafana 접속 (admin/admin)
     - `http://localhost:9090/targets` — `myfave-api` State: UP
     - Grafana → Explore → Loki → `{container="myfave-app"}` 로그 출력

  ## ⚠️ 리뷰어에게 전달 사항
  - `docker-compose.monitoring.yml`은 반드시 기존 `docker-compose.yml`과 `-f` 옵션으로 함께 실행해야 합니다.
  - Promtail이 Docker 소켓에 접근하기 위해 `user: root`로 실행됩니다.
  - Tempo/Loki 이미지에 `wget`/`curl`이 없어 healthcheck를 제거했습니다. 컨테이너 자체는 정상 동작합니다.

  ## 📋 셀프 체크리스트
  - [x] 코드 컨벤션을 준수했나요?
  - [x] 불필요한 주석/로그를 제거했나요?
  - [ ] 테스트를 작성/업데이트했나요?
  - [x] PR 제목이 명확한가요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 애플리케이션 상태(헬스) 및 Prometheus 메트릭 엔드포인트 공개로 외부 모니터링 가능
  * Grafana 대시보드, Prometheus, Loki, Tempo 기반 통합 모니터링 스택 추가

* **Chores**
  * 컨테이너 및 오브저버빌리티 설정(로그·트레이스·메트릭) 구성 및 운영 편의성 개선
  * 서비스 식별 및 추적 정보 표준화로 관찰성 일관성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->