### PR TITLE
fix: types.ts 중복 선언 제거로 Vercel 빌드 오류 수정

### DIFF
--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -10,14 +10,8 @@ export interface Product {
   title: string
   image: string
   price: string
-  category?: ProductCategory
-  isSoldOut?: boolean
   category: ProductCategory
-}
-
-export interface ProductFeature {
-  title: string
-  description: string
+  isSoldOut?: boolean
 }
 
 export interface ProductDetail {


### PR DESCRIPTION
## Summary

- `bc48ad6` 머지 커밋에서 잘못 해결된 충돌로 인해 `ProductFeature` 인터페이스와 `Product.category` 속성이 각각 이중 선언됨
- TypeScript `Duplicate identifier` 에러 발생 → `tsc -b` 실패 → Vercel 프로덕션 빌드 실패
- 중복 선언 제거로 타입 정합성 복구

## Root Cause

`docs/auth-code-comments` 브랜치를 develop에 머지할 때 (`bc48ad6`) 충돌 해결 오류:
- `Product` 인터페이스에 `category?: ProductCategory` (구버전)과 `category: ProductCategory` (fix) 동시 존재
- `ProductFeature` 인터페이스가 파일 내 2회 선언

## Changes

`frontend/src/features/products/types.ts` 1개 파일만 수정 (1줄 추가, 7줄 삭제)
- 중복 `category?: ProductCategory` 제거
- 중복 `ProductFeature` 인터페이스 제거

## Test Plan

- [ ] `tsc --noEmit` 에러 없음 확인
- [ ] Vercel 프리뷰 빌드 통과 확인
- [ ] `ProductListPage`, `ProductDetailPage` 정상 렌더링 확인