### PR TITLE
fix: Spring Security CORS 설정에 CorsConfigurationSource Bean 추가

### DIFF
--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -19,6 +19,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -84,5 +89,29 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Spring Security가 CORS 처리에 사용할 CorsConfigurationSource.
+     * WebMvcConfigurer의 addCorsMappings는 Security 필터 체인에 자동 적용되지 않으므로
+     * 명시적 Bean으로 정의하여 .cors(Customizer.withDefaults())가 이 Bean을 사용하도록 함.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of(
+                "https://www.myfave.shop",
+                "https://myfave.shop",
+                "http://localhost:5173"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization", "X-Trace-Id"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
## 문제                                                                                                                                                              
                                                                                                                                                                       
  운영 사이트 (https://www.myfave.shop)에서 백엔드(`api.myfave.shop`) 호출 시                                                                                          
  모든 요청이 `Invalid CORS request` 403 에러로 차단됨.                                                                                                                
                                                                                                                                                                       
  curl로 직접 호출 시:                                                                                                                                                 
  - Origin 헤더 없음 → 정상 응답 (200/404)                                                                                                                             
  - Origin: https://www.myfave.shop → 403 "Invalid CORS request"                                                                                                       
                                                                                                                                                                       
  ## 원인                                                                                                                                                              
                                                                                                                                                                       
  `WebMvcConfigurer.addCorsMappings()`로 등록한 CORS 설정은                                                                                                            
  Spring MVC 레벨에서만 작동하고, Spring Security 필터 체인에는 자동 적용되지 않음.                                                                                    
                                                                                                                                                                       
  `SecurityConfig.cors(Customizer.withDefaults())`는 컨텍스트에서                                                                                                      
  `CorsConfigurationSource` 빈을 찾는데 그 빈이 없어서 모든 origin 거절.                                                                                               
                                                                                                                                                                       
  ## 해결         
                                                                                                                                                                       
  `SecurityConfig`에 `CorsConfigurationSource` 빈 명시적 등록:                                                                                                         
  - 허용 origin: www.myfave.shop / myfave.shop / localhost:5173
  - 허용 메서드 / 헤더 / credentials / maxAge 설정                                                                                                                     
                                                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 개선사항**
  * 보안 설정을 업데이트하여 특정 도메인과 포트에서의 요청이 올바르게 처리되도록 구성했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->