### PR TITLE
feat: 채팅 메트릭을 D 명세(ws-metrics-contract)에 맞춤

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatMessageController.java
@@ -9,6 +9,8 @@ import com.myfave.api.domain.chat.service.ChatMessageService;
 import com.myfave.api.domain.chat.service.RedisPublisher;
 import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.service.UserService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,7 @@ public class ChatMessageController {
     private final RedisPublisher redisPublisher;
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     @MessageMapping("/chat/{roomId}")
     public void sendMessage(@DestinationVariable Long roomId,
@@ -73,6 +76,13 @@ public class ChatMessageController {
         String json = objectMapper.writeValueAsString(response);
         chatMessageService.save(roomId, json);
         redisPublisher.publish(roomId, json);
+
+        // 메시지 발행 카운트 (k6 수신과 대조)
+        Counter.builder("myfave.chat.messages.published")
+                .description("클라이언트가 발행한 채팅 메시지 누적 수")
+                .tag("room", String.valueOf(roomId))
+                .register(meterRegistry)
+                .increment();
     }
 
     @MessageExceptionHandler

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/ChatMessageService.java
@@ -1,5 +1,7 @@
 package com.myfave.api.domain.chat.service;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,6 +24,7 @@ public class ChatMessageService {
     private static final Duration RATE_LIMIT_TTL = Duration.ofSeconds(3);
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final MeterRegistry meterRegistry;
 
     public void save(Long roomId, String json) {
         String key = CHAT_HISTORY_KEY + roomId;
@@ -47,6 +50,14 @@ public class ChatMessageService {
         if (count != null && count == 1) {
             redisTemplate.expire(key, RATE_LIMIT_TTL);
         }
-        return count != null && count > 1;
+        boolean limited = count != null && count > 1;
+        if (limited) {
+            // rate limit으로 거절된 메시지 카운트 (throttle 작동 검증)
+            Counter.builder("myfave.chat.ratelimit.rejected")
+                    .description("rate limit으로 거절된 채팅 메시지 누적 수")
+                    .register(meterRegistry)
+                    .increment();
+        }
+        return limited;
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/chat/service/RedisSubscriber.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/service/RedisSubscriber.java
@@ -1,11 +1,9 @@
 package com.myfave.api.domain.chat.service;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -39,13 +37,6 @@ public class RedisSubscriber implements MessageListener {
                     .description("Redis pub/sub → WebSocket broadcast 소요 시간")
                     .tag("room", String.valueOf(roomId))
                     .register(meterRegistry));
-
-            // Counter 증가: 메시지 발행 횟수
-            Counter.builder("myfave.chat.messages.broadcast")
-                    .description("WebSocket으로 broadcast된 채팅 메시지 누적 수")
-                    .tag("room", String.valueOf(roomId))
-                    .register(meterRegistry)
-                    .increment();
 
             log.debug("브로드캐스트: roomId={}", roomId);
         } catch (NumberFormatException e) {


### PR DESCRIPTION
D와 합의된 명세에 따라 메트릭 정리:

추가:
- myfave.chat.messages.published (Counter, room 태그) → ChatMessageController.sendMessage()에서 발행 직후 카운트 → k6 수신 vs 백엔드 발행 횟수 대조용
- myfave.chat.ratelimit.rejected (Counter) → ChatMessageService.isRateLimited()의 거절 분기에서 카운트 → throttle 작동 검증용

제거:
- myfave.chat.messages.broadcast (RedisSubscriber) → published 메트릭과 의미 중복, 명세에서 빠짐

유지:
- myfave.websocket.sessions.active (Gauge)
- myfave.chat.broadcast.duration (Timer, room 태그)

## 📌 관련 이슈
Closes #이슈번호

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 채팅 메시지 발행 및 전송에 대한 시스템 모니터링이 강화되었습니다.
  * 메시지 요청 제한 및 브로드캐스트 성능에 대한 메트릭 수집이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->