### PR TITLE
fix: SpringDoc Swagger UI 500 에러 — kotlin-reflect 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 
     // Swagger (SpringDoc)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+    // SpringDoc 2.8.0이 KotlinDeprecatedPropertyCustomizer에서 kotlin.reflect.full.KClasses를 호출 → kotlin-reflect 의존성 필수
+    runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## 문제                                                                                                                                                              
                                                                                                                                                                       
  Swagger UI (http://localhost:8080/api/v1/swagger-ui/index.html) 접근 시                                                                                              
  HTTP 500 발생.                                                                                                                                                       
                                                                                                                                                                       
  ## 원인                                                                                                                                                              
                                                                                                                                                                       
  스택 트레이스:                                                                                                                                                       
  NoClassDefFoundError: kotlin/reflect/full/KClasses                                                                                                                   
    at org.springdoc.core.customizers.KotlinDeprecatedPropertyCustomizer.resolve                                                                                       
                                                                                                                                                                       
  SpringDoc 2.8.0이 swagger 페이지 렌더링 시 Kotlin reflect를 호출하는데                                                                                               
  프로젝트가 순수 Java라 kotlin-reflect 의존성이 없음.                                                                                                                 
                                                                                                                                                                       
  최근 develop에 Observability/Tracing 의존성이 추가되면서                                                                                                           
  SpringDoc의 Kotlin 처리 경로가 활성화되어 잠재 버그가 표면화.                                                                                                        
                                                                                                                                                                       
  ## 해결
                                                                                                                                                                       
  build.gradle에 `runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect'` 추가.                                                                                             
   