### PR TITLE
feat: 회원가입 이메일 인증 기능 추가

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.myfave.api.domain.auth.dto.request.LoginRequest;
 import com.myfave.api.domain.auth.dto.request.PasswordResetSendCodeRequest;
 import com.myfave.api.domain.auth.dto.request.ReissueRequest;
 import com.myfave.api.domain.auth.dto.request.SignUpRequest;
+import com.myfave.api.domain.auth.dto.request.SignUpSendCodeRequest;
+import com.myfave.api.domain.auth.dto.request.SignUpVerifyCodeRequest;
 import com.myfave.api.domain.auth.dto.request.ResetPasswordRequest;
 import com.myfave.api.domain.auth.dto.request.SocialLoginRequest;
 import com.myfave.api.domain.auth.dto.request.VerifyCodeRequest;
@@ -12,6 +14,7 @@ import com.myfave.api.domain.auth.dto.response.FindEmailResponse;
 import com.myfave.api.domain.auth.dto.response.LoginResponse;
 import com.myfave.api.domain.auth.dto.response.ReissueResponse;
 import com.myfave.api.domain.auth.dto.response.SignUpResponse;
+import com.myfave.api.domain.auth.dto.response.SignUpVerifyCodeResponse;
 import com.myfave.api.domain.auth.dto.response.SocialLoginResponse;
 import com.myfave.api.domain.auth.dto.response.VerifyCodeResponse;
 import com.myfave.api.domain.auth.service.AuthService;
@@ -28,6 +31,17 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+
+    @PostMapping("/signup/send-code")
+    public ApiResponse<Void> sendSignUpCode(@Valid @RequestBody SignUpSendCodeRequest request) {
+        authService.sendSignUpCode(request);
+        return new ApiResponse<>(200, "인증코드가 이메일로 발송되었습니다.", null);
+    }
+
+    @PostMapping("/signup/verify-code")
+    public ApiResponse<SignUpVerifyCodeResponse> verifySignUpCode(@Valid @RequestBody SignUpVerifyCodeRequest request) {
+        return new ApiResponse<>(200, "인증코드 확인 완료", authService.verifySignUpCode(request));
+    }
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpRequest.java
@@ -33,4 +33,7 @@ public class SignUpRequest {
     @NotBlank
     @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (010-XXXX-XXXX)")
     private String phone;
+
+    @NotBlank
+    private String verifiedToken;
 }

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpSendCodeRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpSendCodeRequest.java
@@ -1,0 +1,13 @@
+package com.myfave.api.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignUpSendCodeRequest {
+
+    @NotBlank
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+}

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpVerifyCodeRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/request/SignUpVerifyCodeRequest.java
@@ -1,0 +1,18 @@
+package com.myfave.api.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SignUpVerifyCodeRequest {
+
+    @NotBlank
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 6, message = "인증코드는 6자리입니다.")
+    private String verificationCode;
+}

--- a/backend/src/main/java/com/myfave/api/domain/auth/dto/response/SignUpVerifyCodeResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/dto/response/SignUpVerifyCodeResponse.java
@@ -1,0 +1,15 @@
+package com.myfave.api.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignUpVerifyCodeResponse {
+
+    private String verifiedToken;
+
+    public static SignUpVerifyCodeResponse of(String verifiedToken) {
+        return new SignUpVerifyCodeResponse(verifiedToken);
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
@@ -120,7 +120,6 @@ public class AuthService {
         if (storedEmail == null || !storedEmail.equals(request.getEmail())) {
             throw new CustomException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
-        redisTemplate.delete(tokenKey);
 
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.USER_DUPLICATE_EMAIL);
@@ -140,7 +139,9 @@ public class AuthService {
                 .phone(request.getPhone())
                 .build();
 
-        return SignUpResponse.from(userRepository.save(user));
+        SignUpResponse result = SignUpResponse.from(userRepository.save(user));
+        redisTemplate.delete(tokenKey);
+        return result;
     }
 
     public LoginResponse login(LoginRequest request) {

--- a/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
@@ -8,6 +8,8 @@ import com.myfave.api.domain.auth.dto.request.LoginRequest;
 import com.myfave.api.domain.auth.dto.request.PasswordResetSendCodeRequest;
 import com.myfave.api.domain.auth.dto.request.ReissueRequest;
 import com.myfave.api.domain.auth.dto.request.SignUpRequest;
+import com.myfave.api.domain.auth.dto.request.SignUpSendCodeRequest;
+import com.myfave.api.domain.auth.dto.request.SignUpVerifyCodeRequest;
 import com.myfave.api.domain.auth.dto.request.ResetPasswordRequest;
 import com.myfave.api.domain.auth.dto.request.SocialLoginRequest;
 import com.myfave.api.domain.auth.dto.request.VerifyCodeRequest;
@@ -15,6 +17,7 @@ import com.myfave.api.domain.auth.dto.response.FindEmailResponse;
 import com.myfave.api.domain.auth.dto.response.LoginResponse;
 import com.myfave.api.domain.auth.dto.response.ReissueResponse;
 import com.myfave.api.domain.auth.dto.response.SignUpResponse;
+import com.myfave.api.domain.auth.dto.response.SignUpVerifyCodeResponse;
 import com.myfave.api.domain.auth.dto.response.SocialLoginResponse;
 import com.myfave.api.domain.auth.dto.response.VerifyCodeResponse;
 import com.myfave.api.domain.user.entity.SocialProvider;
@@ -57,10 +60,68 @@ public class AuthService {
     private static final long SEND_LIMIT_TTL_MINUTES = 5L;
     private static final long CODE_TTL_MINUTES = 5L;
     private static final long RESET_TOKEN_TTL_MINUTES = 10L;
+    private static final long SIGNUP_VERIFIED_TOKEN_TTL_MINUTES = 10L;
     private static final SecureRandom RANDOM = new SecureRandom();
+
+    public void sendSignUpCode(SignUpSendCodeRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.USER_DUPLICATE_EMAIL);
+        }
+
+        String countKey = "signup-code-count:" + request.getEmail();
+        Long sendCount = redisTemplate.opsForValue().increment(countKey);
+        if (sendCount == 1) {
+            redisTemplate.expire(countKey, SEND_LIMIT_TTL_MINUTES, TimeUnit.MINUTES);
+        }
+        if (sendCount > MAX_SEND_COUNT) {
+            throw new CustomException(ErrorCode.AUTH_TOO_MANY_REQUESTS);
+        }
+
+        String code = String.format("%06d", RANDOM.nextInt(1_000_000));
+        redisTemplate.opsForValue().set(
+                "signup-code:" + request.getEmail(),
+                code,
+                CODE_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        mailService.sendSignUpCode(request.getEmail(), code);
+    }
+
+    public SignUpVerifyCodeResponse verifySignUpCode(SignUpVerifyCodeRequest request) {
+        String codeKey = "signup-code:" + request.getEmail();
+        String storedCode = (String) redisTemplate.opsForValue().get(codeKey);
+
+        if (storedCode == null) {
+            throw new CustomException(ErrorCode.AUTH_EXPIRED_VERIFICATION_CODE);
+        }
+        if (!storedCode.equals(request.getVerificationCode())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_VERIFICATION_CODE);
+        }
+
+        redisTemplate.delete(codeKey);
+
+        String verifiedToken = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(
+                "signup-verified-token:" + verifiedToken,
+                request.getEmail(),
+                SIGNUP_VERIFIED_TOKEN_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        return SignUpVerifyCodeResponse.of(verifiedToken);
+    }
 
     @Transactional
     public SignUpResponse signUp(SignUpRequest request) {
+        String tokenKey = "signup-verified-token:" + request.getVerifiedToken();
+        String storedEmail = (String) redisTemplate.opsForValue().get(tokenKey);
+
+        if (storedEmail == null || !storedEmail.equals(request.getEmail())) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+        }
+        redisTemplate.delete(tokenKey);
+
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.USER_DUPLICATE_EMAIL);
         }

--- a/backend/src/main/java/com/myfave/api/global/common/ApiResponse.java
+++ b/backend/src/main/java/com/myfave/api/global/common/ApiResponse.java
@@ -1,15 +1,30 @@
 package com.myfave.api.global.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.myfave.api.global.error.ErrorCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
     private int code;
     private String message;
+    private String errorCode;
     private T data;
+
+    public ApiResponse(int code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.errorCode = null;
+        this.data = data;
+    }
+
+    private ApiResponse(int code, String message, String errorCode, T data) {
+        this.code = code;
+        this.message = message;
+        this.errorCode = errorCode;
+        this.data = data;
+    }
 
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(200, "OK", data);
@@ -24,6 +39,6 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {
-        return new ApiResponse<>(errorCode.getHttpStatus(), errorCode.getMessage(), null);
+        return new ApiResponse<>(errorCode.getHttpStatus(), errorCode.getMessage(), errorCode.name(), null);
     }
 }

--- a/backend/src/main/java/com/myfave/api/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/myfave/api/global/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     AUTH_SOCIAL_PROVIDER_ERROR(502, "소셜 제공자 서버 오류"),
     AUTH_SOCIAL_EMAIL_REQUIRED(400, "카카오 계정에 이메일 제공 동의가 필요합니다"),
     AUTH_SOCIAL_ACCOUNT_CONFLICT(409, "이미 다른 카카오 계정과 연결된 이메일입니다"),
+    AUTH_EMAIL_NOT_VERIFIED(401, "이메일 인증이 완료되지 않았습니다"),
 
     // 사용자
     USER_NOT_FOUND(404, "회원 정보 없음"),

--- a/backend/src/main/java/com/myfave/api/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/myfave/api/global/error/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     AUTH_SOCIAL_PROVIDER_ERROR(502, "소셜 제공자 서버 오류"),
     AUTH_SOCIAL_EMAIL_REQUIRED(400, "카카오 계정에 이메일 제공 동의가 필요합니다"),
     AUTH_SOCIAL_ACCOUNT_CONFLICT(409, "이미 다른 카카오 계정과 연결된 이메일입니다"),
-    AUTH_EMAIL_NOT_VERIFIED(401, "이메일 인증이 완료되지 않았습니다"),
+    AUTH_EMAIL_NOT_VERIFIED(400, "이메일 인증이 완료되지 않았습니다"),
 
     // 사용자
     USER_NOT_FOUND(404, "회원 정보 없음"),

--- a/backend/src/main/java/com/myfave/api/global/mail/MailService.java
+++ b/backend/src/main/java/com/myfave/api/global/mail/MailService.java
@@ -27,4 +27,14 @@ public class MailService {
         message.setText("인증코드: " + code + "\n\n5분 내로 입력해 주세요.");
         mailSender.send(message);
     }
+
+    @Async("emailExecutor")
+    public void sendSignUpCode(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setSubject("[MyFave] 회원가입 이메일 인증코드");
+        message.setText("인증코드: " + code + "\n\n5분 내로 입력해 주세요.");
+        mailSender.send(message);
+    }
 }

--- a/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSignUpEmailTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSignUpEmailTest.java
@@ -197,4 +197,40 @@ class AuthServiceSignUpEmailTest {
 
         verify(userRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("유효한 verifiedToken과 중복 없는 정보로 회원가입 성공")
+    void signUp_success() {
+        com.myfave.api.domain.auth.dto.request.SignUpRequest request =
+                new com.myfave.api.domain.auth.dto.request.SignUpRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        ReflectionTestUtils.setField(request, "password", "Password1!");
+        ReflectionTestUtils.setField(request, "name", "테스터");
+        ReflectionTestUtils.setField(request, "nickname", "tester");
+        ReflectionTestUtils.setField(request, "phone", "010-1234-5678");
+        ReflectionTestUtils.setField(request, "verifiedToken", "valid-uuid");
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-verified-token:valid-uuid")).willReturn("test@example.com");
+        given(userRepository.existsByEmail("test@example.com")).willReturn(false);
+        given(userRepository.existsByNickname("tester")).willReturn(false);
+        given(userRepository.existsByPhone("010-1234-5678")).willReturn(false);
+        given(passwordEncoder.encode("Password1!")).willReturn("encoded-password");
+
+        com.myfave.api.domain.user.entity.User savedUser =
+                com.myfave.api.domain.user.entity.User.builder()
+                        .email("test@example.com")
+                        .password("encoded-password")
+                        .name("테스터")
+                        .nickname("tester")
+                        .phone("010-1234-5678")
+                        .build();
+        given(userRepository.save(any())).willReturn(savedUser);
+
+        com.myfave.api.domain.auth.dto.response.SignUpResponse response = authService.signUp(request);
+
+        assertThat(response.getNickname()).isEqualTo("tester");
+        verify(redisTemplate).delete("signup-verified-token:valid-uuid");
+        verify(userRepository).save(any());
+    }
 }

--- a/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSignUpEmailTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSignUpEmailTest.java
@@ -1,0 +1,200 @@
+package com.myfave.api.domain.auth.service;
+
+import com.myfave.api.domain.auth.client.KakaoAuthClient;
+import com.myfave.api.domain.auth.dto.request.SignUpSendCodeRequest;
+import com.myfave.api.domain.auth.dto.request.SignUpVerifyCodeRequest;
+import com.myfave.api.domain.auth.dto.response.SignUpVerifyCodeResponse;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import com.myfave.api.global.mail.MailService;
+import com.myfave.api.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceSignUpEmailTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private AuthenticationManager authenticationManager;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOperations;
+    @Mock private MailService mailService;
+    @Mock private KakaoAuthClient kakaoAuthClient;
+
+    @InjectMocks
+    private AuthService authService;
+
+    /* ────────────────── sendSignUpCode ────────────────── */
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 인증코드 발송 시 USER_DUPLICATE_EMAIL 예외 발생")
+    void sendSignUpCode_duplicateEmail_throwsException() {
+        SignUpSendCodeRequest request = new SignUpSendCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        given(userRepository.existsByEmail("test@example.com")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.sendSignUpCode(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_DUPLICATE_EMAIL));
+
+        verify(redisTemplate, never()).opsForValue();
+    }
+
+    @Test
+    @DisplayName("5회 초과 발송 요청 시 AUTH_TOO_MANY_REQUESTS 예외 발생")
+    void sendSignUpCode_exceedLimit_throwsException() {
+        SignUpSendCodeRequest request = new SignUpSendCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        given(userRepository.existsByEmail("test@example.com")).willReturn(false);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("signup-code-count:test@example.com")).willReturn(6L);
+
+        assertThatThrownBy(() -> authService.sendSignUpCode(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_TOO_MANY_REQUESTS));
+
+        verify(mailService, never()).sendSignUpCode(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("첫 번째 발송 - Redis count TTL 설정 및 메일 발송")
+    void sendSignUpCode_firstSend_success() {
+        SignUpSendCodeRequest request = new SignUpSendCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        given(userRepository.existsByEmail("test@example.com")).willReturn(false);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("signup-code-count:test@example.com")).willReturn(1L);
+
+        authService.sendSignUpCode(request);
+
+        verify(redisTemplate).expire("signup-code-count:test@example.com", 5L, TimeUnit.MINUTES);
+        verify(valueOperations).set(
+                eq("signup-code:test@example.com"),
+                anyString(),
+                eq(5L),
+                eq(TimeUnit.MINUTES)
+        );
+        verify(mailService).sendSignUpCode(eq("test@example.com"), anyString());
+    }
+
+    /* ────────────────── verifySignUpCode ────────────────── */
+
+    @Test
+    @DisplayName("만료된 인증코드 검증 시 AUTH_EXPIRED_VERIFICATION_CODE 예외 발생")
+    void verifySignUpCode_expired_throwsException() {
+        SignUpVerifyCodeRequest request = new SignUpVerifyCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        ReflectionTestUtils.setField(request, "verificationCode", "123456");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-code:test@example.com")).willReturn(null);
+
+        assertThatThrownBy(() -> authService.verifySignUpCode(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_EXPIRED_VERIFICATION_CODE));
+    }
+
+    @Test
+    @DisplayName("잘못된 인증코드 입력 시 AUTH_INVALID_VERIFICATION_CODE 예외 발생")
+    void verifySignUpCode_wrongCode_throwsException() {
+        SignUpVerifyCodeRequest request = new SignUpVerifyCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        ReflectionTestUtils.setField(request, "verificationCode", "999999");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-code:test@example.com")).willReturn("123456");
+
+        assertThatThrownBy(() -> authService.verifySignUpCode(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_INVALID_VERIFICATION_CODE));
+    }
+
+    @Test
+    @DisplayName("정상 인증코드 검증 - 코드 삭제 후 verifiedToken 발급")
+    void verifySignUpCode_success() {
+        SignUpVerifyCodeRequest request = new SignUpVerifyCodeRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        ReflectionTestUtils.setField(request, "verificationCode", "123456");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-code:test@example.com")).willReturn("123456");
+
+        SignUpVerifyCodeResponse response = authService.verifySignUpCode(request);
+
+        verify(redisTemplate).delete("signup-code:test@example.com");
+        verify(valueOperations).set(
+                startsWith("signup-verified-token:"),
+                eq("test@example.com"),
+                eq(10L),
+                eq(TimeUnit.MINUTES)
+        );
+        assertThat(response.getVerifiedToken()).isNotBlank();
+    }
+
+    /* ────────────────── signUp (verifiedToken 검증) ────────────────── */
+
+    @Test
+    @DisplayName("존재하지 않는 verifiedToken으로 가입 시도 시 AUTH_EMAIL_NOT_VERIFIED 예외")
+    void signUp_missingVerifiedToken_throwsException() {
+        com.myfave.api.domain.auth.dto.request.SignUpRequest request =
+                new com.myfave.api.domain.auth.dto.request.SignUpRequest();
+        ReflectionTestUtils.setField(request, "email", "test@example.com");
+        ReflectionTestUtils.setField(request, "password", "Password1!");
+        ReflectionTestUtils.setField(request, "name", "테스터");
+        ReflectionTestUtils.setField(request, "nickname", "tester");
+        ReflectionTestUtils.setField(request, "phone", "010-1234-5678");
+        ReflectionTestUtils.setField(request, "verifiedToken", "no-such-token");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-verified-token:no-such-token")).willReturn(null);
+
+        assertThatThrownBy(() -> authService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_EMAIL_NOT_VERIFIED));
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("verifiedToken의 이메일과 요청 이메일 불일치 시 AUTH_EMAIL_NOT_VERIFIED 예외")
+    void signUp_emailMismatch_throwsException() {
+        com.myfave.api.domain.auth.dto.request.SignUpRequest request =
+                new com.myfave.api.domain.auth.dto.request.SignUpRequest();
+        ReflectionTestUtils.setField(request, "email", "other@example.com");
+        ReflectionTestUtils.setField(request, "password", "Password1!");
+        ReflectionTestUtils.setField(request, "name", "테스터");
+        ReflectionTestUtils.setField(request, "nickname", "tester");
+        ReflectionTestUtils.setField(request, "phone", "010-1234-5678");
+        ReflectionTestUtils.setField(request, "verifiedToken", "valid-uuid");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("signup-verified-token:valid-uuid")).willReturn("test@example.com");
+
+        assertThatThrownBy(() -> authService.signUp(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTH_EMAIL_NOT_VERIFIED));
+
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSocialLoginTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceSocialLoginTest.java
@@ -91,7 +91,7 @@ class AuthServiceSocialLoginTest {
         assertThat(response.isNewUser()).isTrue();
         assertThat(response.getAccessToken()).isEqualTo("access-token");
         assertThat(response.getUserId()).isEqualTo(10L);
-        assertThat(response.getEmail()).isEqualTo("user@kakao.com");
+        assertThat(response.getNickname()).isEqualTo("패션왕");
         verify(userRepository).save(any(User.class));
     }
 
@@ -116,6 +116,6 @@ class AuthServiceSocialLoginTest {
 
         assertThat(response.isNewUser()).isFalse();
         assertThat(response.getAccessToken()).isEqualTo("access-token");
-        assertThat(response.getEmail()).isEqualTo("user@kakao.com");
+        assertThat(response.getNickname()).isEqualTo("패션왕");
     }
 }

--- a/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/chat/service/ChatServiceGetRoomInfoTest.java
@@ -66,13 +66,14 @@ class ChatServiceGetRoomInfoTest {
                         .isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 
-    private ChatRoom buildActiveChatRoom(Long id) {
+    private ChatRoom buildActiveChatRoom(Long id, ZonedDateTime createdAt) {
         try {
             var constructor = ChatRoom.class.getDeclaredConstructors()[0];
             constructor.setAccessible(true);
             ChatRoom room = (ChatRoom) constructor.newInstance();
             setField(room, "chatRoomId", id);
             setField(room, "isActive", true);
+            setField(room, "createdAt", createdAt);
             return room;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -4,11 +4,33 @@ import type { ApiResponse } from '@/shared/api/types'
 import type {
   LoginRequest,
   LoginResponse,
+  SignUpSendCodeRequest,
+  SignUpVerifyCodeRequest,
+  SignUpVerifyCodeResponse,
+  SignUpRequest,
+  SignUpResponse,
   SocialLoginRequest,
   SocialLoginResponse,
 } from './types'
 
 export const authApi = {
+  sendSignUpCode: async (body: SignUpSendCodeRequest): Promise<void> => {
+    await apiClient.post<ApiResponse<void>>('/auth/signup/send-code', body)
+  },
+
+  verifySignUpCode: async (body: SignUpVerifyCodeRequest): Promise<SignUpVerifyCodeResponse> => {
+    const { data } = await apiClient.post<ApiResponse<SignUpVerifyCodeResponse>>(
+      '/auth/signup/verify-code',
+      body,
+    )
+    return data.data
+  },
+
+  signUp: async (body: SignUpRequest): Promise<SignUpResponse> => {
+    const { data } = await apiClient.post<ApiResponse<SignUpResponse>>('/auth/signup', body)
+    return data.data
+  },
+
   login: async (body: LoginRequest) => {
     const { data } = await apiClient.post<ApiResponse<LoginResponse>>('/auth/login', body)
     return data.data

--- a/frontend/src/features/auth/hooks.ts
+++ b/frontend/src/features/auth/hooks.ts
@@ -2,6 +2,11 @@ import { useMutation } from '@tanstack/react-query'
 
 import { authApi } from './api'
 import { useAuthStore } from './store'
+import type {
+  SignUpSendCodeRequest,
+  SignUpVerifyCodeRequest,
+  SignUpRequest,
+} from './types'
 
 export function useLogin() {
   const login = useAuthStore((s) => s.login)
@@ -42,4 +47,22 @@ export function useIsAuthenticated() {
 
 export function useLogout() {
   return useAuthStore((s) => s.logout)
+}
+
+export function useSendSignUpCode() {
+  return useMutation({
+    mutationFn: (body: SignUpSendCodeRequest) => authApi.sendSignUpCode(body),
+  })
+}
+
+export function useVerifySignUpCode() {
+  return useMutation({
+    mutationFn: (body: SignUpVerifyCodeRequest) => authApi.verifySignUpCode(body),
+  })
+}
+
+export function useSignUp() {
+  return useMutation({
+    mutationFn: (body: SignUpRequest) => authApi.signUp(body),
+  })
 }

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -28,3 +28,30 @@ export interface SocialLoginResponse {
   email: string
   isNewUser: boolean
 }
+
+export interface SignUpSendCodeRequest {
+  email: string
+}
+
+export interface SignUpVerifyCodeRequest {
+  email: string
+  verificationCode: string
+}
+
+export interface SignUpVerifyCodeResponse {
+  verifiedToken: string
+}
+
+export interface SignUpRequest {
+  email: string
+  password: string
+  name: string
+  nickname: string
+  phone: string
+  verifiedToken: string
+}
+
+export interface SignUpResponse {
+  userId: number
+  nickname: string
+}

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -257,7 +257,7 @@ export function SignUpPage() {
               <button
                 type="button"
                 onClick={isCodeSent ? handleVerifyCode : handleSendCode}
-                disabled={sendSignUpCode.isPending || verifySignUpCode.isPending}
+                disabled={(!isCodeSent && !formData.email) || sendSignUpCode.isPending || verifySignUpCode.isPending}
                 className="flex h-[35px] w-full items-center justify-center rounded-[5px] bg-point font-noto text-[16px] font-bold text-white shadow-sm disabled:opacity-60"
               >
                 {isCodeSent ? '확인' : '인증번호 발송하기'}

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -1,12 +1,17 @@
 import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { PopUp } from '@/shared/components/PopUp'
+import { useSendSignUpCode, useVerifySignUpCode, useSignUp } from '@/features/auth/hooks'
 
 type SignUpStep = 'EMAIL' | 'PASSWORD' | 'NAME' | 'PHONE' | 'NICKNAME' | 'AGREEMENT'
 type TermsView = 'NONE' | 'TERMS' | 'PRIVACY_REQ' | 'PRIVACY_OPT' | 'MARKETING'
 
 export function SignUpPage() {
   const navigate = useNavigate()
+  const sendSignUpCode = useSendSignUpCode()
+  const verifySignUpCode = useVerifySignUpCode()
+  const signUpMutation = useSignUp()
+  const [verifiedToken, setVerifiedToken] = useState('')
   const [step, setStep] = useState<SignUpStep>('AGREEMENT')
   const [isPopUpOpen, setIsPopUpOpen] = useState(false)
   const [popUpMessage, setPopUpMessage] = useState('')
@@ -48,9 +53,67 @@ export function SignUpPage() {
     return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
   }
 
+  const getErrorMessage = (error: unknown): string => {
+    const errorCode = (error as { response?: { data?: { errorCode?: string } } })
+      ?.response?.data?.errorCode
+    switch (errorCode) {
+      case 'USER_DUPLICATE_EMAIL': return '이미 가입된 이메일입니다'
+      case 'AUTH_TOO_MANY_REQUESTS': return '잠시 후 다시 시도해주세요'
+      case 'AUTH_EXPIRED_VERIFICATION_CODE': return '인증코드가 만료되었습니다'
+      case 'AUTH_INVALID_VERIFICATION_CODE': return '인증코드가 일치하지 않습니다'
+      case 'AUTH_EMAIL_NOT_VERIFIED': return '이메일 인증이 필요합니다'
+      case 'USER_DUPLICATE_NICKNAME': return '이미 사용 중인 닉네임입니다'
+      case 'USER_DUPLICATE_PHONE': return '이미 등록된 전화번호입니다'
+      default: return '오류가 발생했습니다. 다시 시도해주세요'
+    }
+  }
+
   const showPopUp = (msg: string) => {
     setPopUpMessage(msg)
     setIsPopUpOpen(true)
+  }
+
+  const handleSendCode = async () => {
+    if (!formData.email) return
+    try {
+      await sendSignUpCode.mutateAsync({ email: formData.email })
+      setIsCodeSent(true)
+      setTimeLeft(180)
+      showPopUp('인증번호가 발송되었습니다 🎁')
+    } catch (error) {
+      showPopUp(getErrorMessage(error))
+    }
+  }
+
+  const handleVerifyCode = async () => {
+    if (!formData.verificationCode) return
+    try {
+      const res = await verifySignUpCode.mutateAsync({
+        email: formData.email,
+        verificationCode: formData.verificationCode,
+      })
+      setVerifiedToken(res.verifiedToken)
+      setStep('PASSWORD')
+    } catch (error) {
+      showPopUp(getErrorMessage(error))
+    }
+  }
+
+  const handleSignUp = async () => {
+    try {
+      await signUpMutation.mutateAsync({
+        email: formData.email,
+        password: formData.password,
+        name: formData.name,
+        nickname: formData.nickname,
+        phone: formData.phone,
+        verifiedToken,
+      })
+      showPopUp('회원가입이 완료되었습니다 ✨')
+      setTimeout(() => navigate('/login'), 2000)
+    } catch (error) {
+      showPopUp(getErrorMessage(error))
+    }
   }
 
   const handleNext = () => {
@@ -180,9 +243,11 @@ export function SignUpPage() {
                   />
                   <div className="absolute right-[19px] flex items-center gap-[10px]">
                     <span className="font-noto text-[16px] font-bold text-[#999999]">{formatTime(timeLeft)}</span>
-                    <button 
-                      onClick={() => { setTimeLeft(180); showPopUp('인증번호가 재발송되었습니다 🎁') }}
-                      className="h-[25px] rounded-[5px] bg-point px-2 font-noto text-[10px] font-bold text-white"
+                    <button
+                      type="button"
+                      onClick={handleSendCode}
+                      disabled={sendSignUpCode.isPending}
+                      className="h-[25px] rounded-[5px] bg-point px-2 font-noto text-[10px] font-bold text-white disabled:opacity-60"
                     >
                       재발송
                     </button>
@@ -190,16 +255,10 @@ export function SignUpPage() {
                 </div>
               )}
               <button
-                onClick={() => {
-                  if (!isCodeSent) {
-                    setIsCodeSent(true)
-                    setTimeLeft(180)
-                    showPopUp('인증번호가 발송되었습니다 🎁')
-                  } else {
-                    handleNext()
-                  }
-                }}
-                className="flex h-[35px] w-full items-center justify-center rounded-[5px] bg-point font-noto text-[16px] font-bold text-white shadow-sm"
+                type="button"
+                onClick={isCodeSent ? handleVerifyCode : handleSendCode}
+                disabled={sendSignUpCode.isPending || verifySignUpCode.isPending}
+                className="flex h-[35px] w-full items-center justify-center rounded-[5px] bg-point font-noto text-[16px] font-bold text-white shadow-sm disabled:opacity-60"
               >
                 {isCodeSent ? '확인' : '인증번호 발송하기'}
               </button>
@@ -310,10 +369,12 @@ export function SignUpPage() {
                 />
               </div>
               <button
-                onClick={handleNext}
-                className="flex h-[35px] w-full items-center justify-center rounded-[5px] bg-point font-noto text-[16px] font-medium text-white shadow-sm"
+                type="button"
+                onClick={handleSignUp}
+                disabled={signUpMutation.isPending}
+                className="flex h-[35px] w-full items-center justify-center rounded-[5px] bg-point font-noto text-[16px] font-medium text-white shadow-sm disabled:opacity-60"
               >
-                다음
+                {signUpMutation.isPending ? '처리 중...' : '다음'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- 회원가입 시 이메일 인증코드(6자리) 발송/검증 후 발급된 `verifiedToken`을 `POST /auth/signup` 요청에 포함시켜 서버가 이메일 소유 여부를 보장
- Redis 키 네임스페이스를 비밀번호 찾기(`pwd-reset-*`)와 완전히 분리(`signup-code-*`, `signup-verified-token-*`)해 충돌 방지
- 에러 응답에 `errorCode` 필드 추가(`@JsonInclude NON_NULL`)로 프론트엔드 에러 파싱 지원

## Changes

### Backend
- `POST /auth/signup/send-code` — 이메일 중복 체크 → 5회 제한 → 인증코드 발송
- `POST /auth/signup/verify-code` — 코드 검증 → `verifiedToken`(UUID, 10분 TTL) 발급
- `POST /auth/signup` — `verifiedToken` Redis 검증 후 회원 저장 (토큰은 save 성공 후 삭제)
- `ApiResponse`에 `errorCode` 필드 추가 (에러 응답에만 포함, 성공 응답에서 숨김)
- `AuthServiceSignUpEmailTest` — 9개 TDD 테스트 (sendSignUpCode 3, verifySignUpCode 3, signUp 3)

### Frontend
- `features/auth/types.ts` — SignUpSendCodeRequest, SignUpVerifyCodeRequest, SignUpVerifyCodeResponse, SignUpRequest, SignUpResponse 타입 추가
- `features/auth/api.ts` — sendSignUpCode, verifySignUpCode, signUp API 함수 추가
- `features/auth/hooks.ts` — useSendSignUpCode, useVerifySignUpCode, useSignUp mutation 훅 추가
- `SignUpPage.tsx` — EMAIL 스텝 실제 API 연동, 인증 완료 후 NICKNAME 스텝에서 최종 가입 API 호출

## Test Plan

- [ ] 신규 이메일 입력 → 인증번호 발송하기 → 이메일로 6자리 코드 수신 확인
- [ ] 잘못된 코드 입력 → "인증코드가 일치하지 않습니다" 팝업 확인
- [ ] 올바른 코드 입력 → PASSWORD 스텝으로 이동 확인
- [ ] 나머지 정보 입력 후 가입 → `/login` 리다이렉트 확인
- [ ] 이미 가입된 이메일 입력 후 발송 → "이미 가입된 이메일입니다" 팝업 확인
- [ ] `POST /auth/signup` 직접 호출 (verifiedToken 없이) → 400 AUTH_EMAIL_NOT_VERIFIED 확인
- [ ] 닉네임 중복으로 가입 실패 시 verifiedToken 유지되어 재시도 가능 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회원가입 시 이메일 인증 기능 추가: 가입 시 이메일로 인증코드를 받아 검증하는 단계 추가
  * 인증코드는 6자리로 5분 내에 입력해야 하며, 발송 횟수 제한 적용

* **Improvements**
  * API 응답에 오류 코드 필드 추가로 더 명확한 오류 처리 제공
  * 이메일 미인증 상태에서 회원가입 완료 차단

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->