### PR TITLE
fix: Swagger UI server URL이 http로 박히던 문제 — forward-headers-strategy 추가

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,6 +15,8 @@ server:
   port: 8080
   servlet:
     context-path: /api/v1 # 모든 API: /api/v1/users, /api/v1/products 등
+  # Nginx 리버스 프록시 뒤에서 X-Forwarded-Proto 헤더 인식 → Swagger UI가 https URL 생성하도록
+  forward-headers-strategy: framework
 
 # CORS 설정 (profile별 override: application-prod.yml)
 app:


### PR DESCRIPTION
## 문제                                                                                                                                                              
                                                                                                                                                                       
  운영 Swagger UI(`https://api.myfave.shop/api/v1/swagger-ui/index.html`)에서                                                                                          
  Try it out → Execute 시 다음 에러로 모든 API 호출 차단:                                                                                                              
                                                                                                                                                                       
    Failed to fetch.                                                                                                                                                   
    URL scheme must be "http" or "https" for CORS request                                                                                                              
                                                                                                                                                                       
  ## 원인                                                                                                                                                              
                                                                                                                                                                       
  Spring Boot가 Nginx 리버스 프록시 뒤에서 자기 scheme을 `http`로 인식.                                                                                                
  이로 인해 SpringDoc이 자동 생성하는 OpenAPI Servers URL이 다음과 같이 박힘:                                                                                          
                                                                                                                                                                       
    Servers: http://api.myfave.shop/api/v1                                                                                                                             
                                                                                                                                                                       
  HTTPS 페이지에서 HTTP API 호출 시도 → 브라우저가 Mixed Content / CORS로 차단.                                                                                        
                  
  ## 해결                                                                                                                                                              
   
  `application.yml`의 `server` 블록에 추가:                                                                                                                            
                  
    forward-headers-strategy: framework

  Spring Boot가 Nginx의 `X-Forwarded-Proto: https` 헤더를 인식해서                                                                                                     
  자기 scheme을 https로 인식 → Servers URL이 `https://api.myfave.shop/api/v1`로 생성.
                

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 리버스 프록시 환경에서 프로토콜 스킴(HTTPS/HTTP) 처리가 개선되었습니다. 프록시 뒤에서 생성되는 URL들이 올바른 프로토콜로 설정됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->