### PR TITLE
refactor: k6 로컬 부하 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ backend/src/main/java/com/myfave/api/domain/payment/*CONTEXT.md
 backend/src/main/java/com/myfave/api/domain/payment/**/*CONTEXT.md
 backend/src/main/java/com/myfave/api/domain/payment/*FLOW.md
 backend/src/main/java/com/myfave/api/domain/payment/**/*FLOW.md
+backend/load-test/*CONTEXT.md
+backend/load-test/**/*CONTEXT.md
 
 # IDE 설정
 .idea/

--- a/backend/src/main/resources/application-loadtest.yml
+++ b/backend/src/main/resources/application-loadtest.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: local
+      SPRING_PROFILES_ACTIVE: load-test
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/myfave

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: load-test
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/myfave

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: load-test
+      SPRING_PROFILES_ACTIVE: loadtest
       S3_BUCKET_NAME: ${S3_BUCKET_NAME}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
 📌 관련 이슈
  Closes #165 

  📝 작업 내용
  부하 테스트(k6)를 원활하게 실행하고 결과를 모니터링하기 위해 Docker 인프라 설정 오류를 수정하고
  백엔드 테스트 프로파일 환경을 구성했습니다.

  🔍 변경 사항
   - [ ] 기능 추가
   - [x] 버그 수정
   - [ ] 리팩토링
   - [ ] 테스트 추가 / 수정
   - [x] 문서 수정
   - [x] 기타 (설명: 부하 테스트용 환경 변수 및 설정 파일 수정)

  💡 구현 방법 / 주요 변경 포인트
   1. 그라파나 기동 실패 해결 (docker-compose.monitoring.yml)
      - 설정 파일 내 ${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set} 안전 장치로 인해 컨테이너
        기동이 차단되는 문제 해결.
      - .env 파일에 GRAFANA_PASSWORD 환경 변수를 명시적으로 추가하여 정상 기동되도록 조치.
   2. 부하 테스트 DB 스키마 생성 오류 해결 (application-loadtest.yml)
      - 기존 ddl-auto: validate 설정으로 인해 빈 DB에서 테이블(예: cart_items, products)을 찾지
        못하고 서버가 다운되는 현상 발생.
      - 로컬 테스트 환경의 원활한 진행을 위해 ddl-auto: update로 변경하여, 테스트 컨테이너 실행 시
        자동으로 최신 스키마가 생성되도록 수정.
   3. k6 테스트 데이터 초기화 프로세스 정립
      - 테스트 시작 전 token-prepare.mjs를 통한 1,000명 유저 시드 데이터 생성.
      - 각 테스트 라운드 전 reset.sql을 통한 상품 재고 데이터 초기화 파이프라인 확립.

  ✅ 테스트 방법
  변경 사항을 검증하는 방법을 작성해 주세요.
   1. 환경 설정:
      - 프로젝트 루트 .env 파일에 GRAFANA_PASSWORD=admin1234 추가.
      - 백엔드 앱의 프로파일을 loadtest로 지정.
   2. 실행 방법:
      - 모니터링 스택 기동: docker-compose -f docker-compose.monitoring.yml up -d
      - 백엔드 앱 기동: docker-compose up -d app (수정된 yml 반영을 위해 필요시 build app 진행)
      - DB 초기화: docker exec -i myfave-postgres psql -U postgres -d myfave <
        backend/load-test/seed/reset.sql
      - 토큰 생성: node backend/load-test/seed/token-prepare.mjs
      - k6 실행: docker run --rm -i --network myfave_myfave-network -v
        $(pwd)/backend/load-test/k6:/k6 -e BASE_URL=http://myfave-app:8080/api/v1 -e
        K6_PROMETHEUS_RW_SERVER_URL=http://myfave-prometheus:9090/api/v1/write grafana/k6 run --out
        experimental-prometheus-rw /k6/scenarios/scenario-a-spike.js
   3. 확인 사항:
      - 모니터링 컨테이너(Grafana, Prometheus 등)가 종료되지 않고 Up 상태 유지 확인.
      - 백엔드 앱 기동 시 missing table [cart_items] 에러 없이 정상적으로 Started 로그 확인.
      - k6 테스트 실행 후 http://localhost:3000 (Grafana)에서 실시간 메트릭 확인.

  📸 스크린샷 (선택)
  (필요 시 그라파나 대시보드 화면 첨부)

  ⚠️ 리뷰어에게 전달 사항
   - 로컬 부하 테스트 편의를 위해 임시로 application-loadtest.yml의 ddl-auto를 update로
     변경했습니다. 만약 실서버(Prod)와 동일한 매우 엄격한 잣대가 필요하다면, DB 마이그레이션
     스크립트(Flyway 등)를 도입하거나 validate 옵션을 다시 복구하는 논의가 필요할 수 있습니다.
   - k6 명령어를 실행할 때 Docker 네트워크 이름(myfave_myfave-network)이 띄어쓰기 없이 정확히
     입력되어야 하니 주의해 주세요.

  📋 셀프 체크리스트
   - [x] 코드 컨벤션을 준수했나요?
   - [x] 불필요한 주석/로그를 제거했나요?
   - [x] 테스트를 작성/업데이트했나요?
   - [x] PR 제목이 명확한가요? (예: [환경설정] k6 부하테스트 인프라 및 DB 초기화 버그 수정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 부하 테스트 환경에 대한 데이터베이스 스키마 처리 방식 변경
  * 실행 프로파일이 부하 테스트로 전환
  * 배포 설정에 S3 버킷 환경변수 추가
  * 버전 관리에서 부하 테스트 관련 컨텍스트 파일 무시 규칙 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->