### PR TITLE
feat: 부하 테스트용 MockPortOnePaymentProvider 추가

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/payment/provider/MockPortOnePaymentProvider.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/provider/MockPortOnePaymentProvider.java
@@ -1,0 +1,60 @@
+package com.myfave.api.domain.payment.provider;
+
+import com.myfave.api.domain.payment.entity.Payment;
+import com.myfave.api.domain.payment.repository.PaymentRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+// 부하 테스트 전용 PaymentProvider mock.
+// 외부 PortOne API 호출 없이 항상 PAID 상태로 응답해 시나리오 D의 PESSIMISTIC 락 검증을 가능하게 함.
+// pgTransactionId 패턴 "MOCK-PAY-{paymentId}"에서 paymentId 파싱 → DB에서 실제 결제 금액 조회.
+@Slf4j
+@Component
+@Profile("loadtest")
+@Primary
+@RequiredArgsConstructor
+public class MockPortOnePaymentProvider implements PaymentProvider {
+
+    private static final String MOCK_PREFIX = "MOCK-PAY-";
+
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public PortOnePaymentInfo getPaymentInfo(String pgTransactionId) {
+        int amount = resolveAmount(pgTransactionId);
+        return new PortOnePaymentInfo(
+                pgTransactionId,
+                "PAID",
+                amount,
+                "https://mock.receipt/" + pgTransactionId,
+                ZonedDateTime.now()
+        );
+    }
+
+    @Override
+    public void cancelPayment(String pgTransactionId, int cancelAmount, String reason) {
+        log.debug("[Mock] cancel pgTransactionId={}, amount={}, reason={}",
+                pgTransactionId, cancelAmount, reason);
+    }
+
+    private int resolveAmount(String pgTransactionId) {
+        if (pgTransactionId == null || !pgTransactionId.startsWith(MOCK_PREFIX)) {
+            return 13000;
+        }
+        try {
+            Long paymentId = Long.parseLong(pgTransactionId.substring(MOCK_PREFIX.length()));
+            Payment payment = paymentRepository.findById(paymentId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
+            return payment.getTotalPaymentPrice();
+        } catch (NumberFormatException e) {
+            return 13000;
+        }
+    }
+}


### PR DESCRIPTION
시나리오 D의 PESSIMISTIC 락 검증이 외부 PortOne 502로 막혀
매진 경쟁(10명만 성공) 측정이 불가능했던 문제 해결.

pgTransactionId "MOCK-PAY-{paymentId}" 패턴 파싱 후
DB의 totalPaymentPrice를 그대로 반환해 amount 검증 통과.
@Profile("loadtest") + @Primary 이므로 prod 환경 영향 없음.

## 📌 관련 이슈
Closes #이슈번호

## 📝 작업 내용
이 PR에서 변경한 내용을 간략히 설명해 주세요.

## 🔍 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [ ] 기타 (설명: )

## 💡 구현 방법 / 주요 변경 포인트
핵심 로직이나 설계 결정 사항을 설명해 주세요.

## ✅ 테스트 방법
변경 사항을 검증하는 방법을 작성해 주세요.
1. 환경 설정:
2. 실행 방법:
3. 확인 사항:

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 전/후 스크린샷을 첨부해 주세요.

## ⚠️ 리뷰어에게 전달 사항
리뷰어가 특히 집중해서 봐줬으면 하는 부분이나 논의가 필요한 부분을 작성해 주세요.

## 📋 셀프 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요?
- [ ] PR 제목이 명확한가요? (예: `[FEAT] 로그인 기능 구현`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 테스트 환경을 위한 Mock 결제 공급자 추가
  * 결제 정보 조회 및 취소 기능 지원으로 개발/테스트 효율성 개선
  * 별도 프로필 설정으로 외부 의존성 없이 결제 처리 테스트 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->