### PR TITLE
refactor: order payment 도메인 메트릭 및 로그 수집

### DIFF
--- a/backend/load-test/k6/lib/context.js
+++ b/backend/load-test/k6/lib/context.js
@@ -1,0 +1,32 @@
+// 부하테스트 라운드/시나리오 라벨 — 모든 HTTP/STOMP 요청 + k6 메트릭에 자동 부착.
+// 백엔드 TraceIdFilter가 X-Loadtest-* 헤더를 MDC에 주입 → 로그/Loki 라벨로 사용.
+// k6 자체 메트릭 (k6_http_req_duration_seconds, k6_vus 등)도 tags로 라운드 비교 가능.
+//
+// 환경변수 (k6 run --env 또는 셸 export):
+//   LOADTEST_RUN_ID    예) 2026-05-25T18:00-D-r0   (라운드별 고유 식별)
+//   LOADTEST_SCENARIO  예) A | B | D | E
+//   LOADTEST_ROUND     예) 0 | 1 | 2 | 3
+
+export const LOADTEST_RUN_ID = __ENV.LOADTEST_RUN_ID || '';
+export const LOADTEST_SCENARIO = __ENV.LOADTEST_SCENARIO || '';
+export const LOADTEST_ROUND = __ENV.LOADTEST_ROUND || '';
+
+// HTTP 요청 헤더로 부착할 객체. http.js의 authHeaders에서 자동 머지.
+export function loadtestHeaders() {
+  const headers = {};
+  if (LOADTEST_RUN_ID) headers['X-Loadtest-Run-Id'] = LOADTEST_RUN_ID;
+  if (LOADTEST_SCENARIO) headers['X-Loadtest-Scenario'] = LOADTEST_SCENARIO;
+  if (LOADTEST_ROUND) headers['X-Loadtest-Round'] = LOADTEST_ROUND;
+  return headers;
+}
+
+// k6 options.tags에 머지하면 모든 k6 메트릭에 라벨 부착됨.
+// 사용: export const options = { tags: { ...loadtestTags() }, scenarios: {...} };
+// → Grafana myfave-loadtest-rounds 대시보드의 $scenario/$round 변수에서 사용.
+export function loadtestTags() {
+  const tags = {};
+  if (LOADTEST_RUN_ID) tags.run_id = LOADTEST_RUN_ID;
+  if (LOADTEST_SCENARIO) tags.scenario = LOADTEST_SCENARIO;
+  if (LOADTEST_ROUND) tags.round = LOADTEST_ROUND;
+  return tags;
+}

--- a/backend/load-test/k6/lib/http.js
+++ b/backend/load-test/k6/lib/http.js
@@ -2,6 +2,7 @@
 // 시나리오 코드를 깔끔하게 유지하기 위함.
 
 import http from 'k6/http';
+import { loadtestHeaders } from './context.js';
 
 export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080/api/v1';
 
@@ -10,6 +11,8 @@ export function authHeaders(token, extra = {}) {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
+      // 부하테스트 Round/Scenario/RunId 헤더 — 모든 HTTP 요청에 자동 부착
+      ...loadtestHeaders(),
       ...extra,
     },
   };

--- a/backend/load-test/k6/lib/stomp.js
+++ b/backend/load-test/k6/lib/stomp.js
@@ -1,16 +1,28 @@
 // STOMP frame 빌더 — k6/ws는 raw WebSocket만 지원하므로 STOMP 프로토콜은 수동으로 직조.
 // 백엔드: spring-boot-starter-websocket + @MessageMapping. 자세한 경로는 시나리오 E 참조.
 
+import { LOADTEST_RUN_ID, LOADTEST_SCENARIO, LOADTEST_ROUND } from './context.js';
+
 // STOMP frame 종료자: NULL byte (0x00). String.fromCharCode로 명시적으로 생성.
 const NULL_BYTE = String.fromCharCode(0);
 
+function loadtestStompHeaders() {
+  const lines = [];
+  if (LOADTEST_RUN_ID) lines.push(`X-Loadtest-Run-Id:${LOADTEST_RUN_ID}`);
+  if (LOADTEST_SCENARIO) lines.push(`X-Loadtest-Scenario:${LOADTEST_SCENARIO}`);
+  if (LOADTEST_ROUND) lines.push(`X-Loadtest-Round:${LOADTEST_ROUND}`);
+  return lines.length > 0 ? lines.join('\n') + '\n' : '';
+}
+
 export function connect(accessToken) {
   // Bearer 토큰은 JwtChannelInterceptor가 STOMP 헤더에서 읽음.
+  // 부하테스트 헤더는 JwtHandshakeInterceptor/ChannelInterceptor에서 MDC로 옮길 수 있음.
   return (
     'CONNECT\n' +
     'accept-version:1.2\n' +
     'host:localhost\n' +
     `Authorization:Bearer ${accessToken}\n` +
+    loadtestStompHeaders() +
     '\n' +
     NULL_BYTE
   );

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -25,7 +25,9 @@ import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +43,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true) // 기본적으로 읽기 전용. 변경이 필요한 메서드에 별도 @Transactional 추가
@@ -53,10 +56,15 @@ public class OrderService {
     private final CartItemRepository cartItemRepository;
     private final ShippingAddressRepository shippingAddressRepository;
     private final DeliveryRepository deliveryRepository;
+    private final MeterRegistry meterRegistry;
 
     // 주문 생성 (5-1)
     @Transactional
     public OrderResponse createOrder(Long userId, OrderCreateRequest request) {
+
+        String type = request.getOrderType() != null ? request.getOrderType().name() : "UNKNOWN";
+        String outcome = "failure";
+        try {
 
         // ── 1. 사용자 조회 ──────────────────────────────────────────────
         if (userId == null) {
@@ -149,7 +157,15 @@ public class OrderService {
 
         // ── 7. 응답 반환 ───────────────────────────────────────────────
         // OrderResponse.from(order): order 엔티티에서 필요한 필드만 뽑아 DTO로 변환
+        int itemCount = orderItemRepository.findByOrder(order).size();
+        log.info("[Order] 주문 생성: orderId={}, userId={}, type={}, itemCount={}",
+                order.getOrderId(), userId, type, itemCount);
+        outcome = "success";
         return OrderResponse.from(order);
+        } finally {
+            meterRegistry.counter("myfave.order.created",
+                    "type", type, "outcome", outcome).increment();
+        }
     }
 
     /**
@@ -269,6 +285,9 @@ public class OrderService {
         // order.confirm(): orderStatus를 PURCHASE_CONFIRMED로 변경
         // @Transactional이므로 메서드 종료 시 JPA가 변경 감지 → UPDATE 쿼리 자동 실행
         order.confirm();
+        meterRegistry.counter("myfave.order.status.transition",
+                "from", "DELIVERY_COMPLETED", "to", "PURCHASE_CONFIRMED").increment();
+        log.info("[Order] 구매확정: orderId={}, userId={}", orderId, userId);
 
         // ── 6. 응답 반환 ─────────────────────────────────────────────────
         // OrderConfirmResponse.from(order): orderId, orderStatus(PURCHASE_CONFIRMED) 반환
@@ -311,5 +330,8 @@ public class OrderService {
         // ── 5. 주문 상태 CANCELLED 전환 ─────────────────────────────────
         // 재고 복구 로직 없음 — Order 생성 시점에 차감하지 않는 정책
         order.cancel();
+        meterRegistry.counter("myfave.order.status.transition",
+                "from", status.name(), "to", "CANCELLED").increment();
+        log.info("[Order] 주문 취소: orderId={}, userId={}, fromStatus={}", orderId, userId, status);
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/payment/provider/PortOnePaymentProvider.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/provider/PortOnePaymentProvider.java
@@ -2,6 +2,8 @@ package com.myfave.api.domain.payment.provider;
 
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -9,66 +11,119 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @Slf4j
 @Component
 public class PortOnePaymentProvider implements PaymentProvider {
 
     private final WebClient webClient;
+    private final MeterRegistry meterRegistry;
 
     public PortOnePaymentProvider(
             WebClient.Builder builder,
             @Value("${portone.api-url}") String apiUrl,
-            @Value("${portone.api-secret}") String apiSecret
+            @Value("${portone.api-secret}") String apiSecret,
+            MeterRegistry meterRegistry
     ) {
         this.webClient = builder
                 .baseUrl(apiUrl)
                 .defaultHeader("Authorization", "PortOne " + apiSecret)
                 .build();
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
     public PortOnePaymentInfo getPaymentInfo(String pgTransactionId) {
-        Map<?, ?> body = webClient.get()
-                .uri("/payments/{id}", pgTransactionId)
-                .retrieve()
-                .onStatus(status -> status.isError(), response ->
-                        response.bodyToMono(String.class)
-                                .map(err -> new CustomException(ErrorCode.PAYMENT_FAILED)))
-                .bodyToMono(Map.class)
-                .block();
+        return invokeWithMetrics("getPaymentInfo", () -> {
+            log.debug("[PortOne] getPaymentInfo 호출: pgTxId={}", pgTransactionId);
+            Map<?, ?> body = webClient.get()
+                    .uri("/payments/{id}", pgTransactionId)
+                    .retrieve()
+                    .onStatus(status -> status.isError(), response -> {
+                        int status = response.statusCode().value();
+                        recordHttpError("getPaymentInfo", status);
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .map(err -> {
+                                    log.warn("[PortOne] getPaymentInfo HTTP 에러: pgTxId={}, status={}, body={}",
+                                            pgTransactionId, status, err);
+                                    return new CustomException(ErrorCode.PAYMENT_FAILED);
+                                });
+                    })
+                    .bodyToMono(Map.class)
+                    .block();
 
-        if (body == null) {
-            throw new CustomException(ErrorCode.PAYMENT_FAILED);
-        }
+            if (body == null) {
+                log.warn("[PortOne] getPaymentInfo 응답 본문 비어있음: pgTxId={}", pgTransactionId);
+                throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            }
 
-        String status = (String) body.get("status");
-        int totalAmount = ((Number) ((Map<?, ?>) body.get("amount")).get("total")).intValue();
-        String receiptUrl = (String) body.get("receiptUrl");
-        ZonedDateTime paidAt = body.get("paidAt") != null
-                ? ZonedDateTime.parse((String) body.get("paidAt"))
-                : null;
+            String status = (String) body.get("status");
+            int totalAmount = ((Number) ((Map<?, ?>) body.get("amount")).get("total")).intValue();
+            String receiptUrl = (String) body.get("receiptUrl");
+            ZonedDateTime paidAt = body.get("paidAt") != null
+                    ? ZonedDateTime.parse((String) body.get("paidAt"))
+                    : null;
 
-        return new PortOnePaymentInfo(pgTransactionId, status, totalAmount, receiptUrl, paidAt);
+            return new PortOnePaymentInfo(pgTransactionId, status, totalAmount, receiptUrl, paidAt);
+        });
     }
 
     @Override
     public void cancelPayment(String pgTransactionId, int cancelAmount, String reason) {
-        Map<?, ?> body = webClient.post()
-                .uri("/payments/{id}/cancel", pgTransactionId)
-                .bodyValue(Map.of(
-                        "reason", reason,
-                        "amount", cancelAmount
-                ))
-                .retrieve()
-                .onStatus(status -> status.isError(), response ->
-                        response.bodyToMono(String.class)
-                                .map(err -> new CustomException(ErrorCode.PAYMENT_FAILED)))
-                .bodyToMono(Map.class)
-                .block();
+        invokeWithMetrics("cancelPayment", () -> {
+            log.debug("[PortOne] cancelPayment 호출: pgTxId={}, amount={}, reason={}",
+                    pgTransactionId, cancelAmount, reason);
+            Map<?, ?> body = webClient.post()
+                    .uri("/payments/{id}/cancel", pgTransactionId)
+                    .bodyValue(Map.of(
+                            "reason", reason,
+                            "amount", cancelAmount
+                    ))
+                    .retrieve()
+                    .onStatus(status -> status.isError(), response -> {
+                        int status = response.statusCode().value();
+                        recordHttpError("cancelPayment", status);
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .map(err -> {
+                                    log.warn("[PortOne] cancelPayment HTTP 에러: pgTxId={}, status={}, body={}",
+                                            pgTransactionId, status, err);
+                                    return new CustomException(ErrorCode.PAYMENT_FAILED);
+                                });
+                    })
+                    .bodyToMono(Map.class)
+                    .block();
 
-        if (body == null) {
-            throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            if (body == null) {
+                log.warn("[PortOne] cancelPayment 응답 본문 비어있음: pgTxId={}", pgTransactionId);
+                throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            }
+            return null;
+        });
+    }
+
+    // PG 호출을 Timer.Sample로 감싸 outcome(success/failure)별 latency 분포 측정.
+    // 서드파티 SLA와 우리 서비스 latency를 분리해서 보기 위함.
+    private <T> T invokeWithMetrics(String api, Supplier<T> call) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
+        try {
+            T result = call.get();
+            outcome = "success";
+            return result;
+        } finally {
+            sample.stop(Timer.builder("myfave.portone.call.duration")
+                    .tag("api", api)
+                    .tag("outcome", outcome)
+                    .register(meterRegistry));
         }
+    }
+
+    private void recordHttpError(String api, int statusCode) {
+        String statusClass = statusCode >= 500 ? "5xx" : statusCode >= 400 ? "4xx" : "other";
+        meterRegistry.counter("myfave.portone.http.errors",
+                "api", api, "status_class", statusClass).increment();
     }
 }

--- a/backend/src/main/java/com/myfave/api/domain/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/repository/PaymentRepository.java
@@ -19,4 +19,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // Reconciliation: 특정 상태 + 생성시각 기준 조회
     List<Payment> findByPaymentStatusAndCreatedAtBefore(PaymentStatus status, ZonedDateTime threshold);
+
+    // myfave.payment.pending.gauge: 현재 PENDING 결제 적체량 관측
+    long countByPaymentStatus(PaymentStatus status);
 }

--- a/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
@@ -30,6 +30,8 @@ import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,6 +69,7 @@ public class PaymentService {
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final PaymentProvider paymentProvider;
+    private final MeterRegistry meterRegistry;
 
     @Lazy
     private final PaymentService self;
@@ -180,56 +183,79 @@ public class PaymentService {
     // 2. 결제 승인 (오케스트레이터: 외부 호출은 트랜잭션 밖) ──────────────────────
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public PaymentResponse confirmPayment(Long userId, PaymentConfirmRequest request) {
-        if (userId == null) {
-            throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
-        }
-        // 1. DB에서 유저와 결제 상태 확인
-        ConfirmContext ctx = self.validateForConfirm(userId, request.getPaymentId());
-
-        // 2. 외부 PG사 통신
-        PortOnePaymentInfo pgInfo = paymentProvider.getPaymentInfo(request.getPgTransactionId());
-
-        //  3. 데이터 무결성 검증 및 롤백
-        if (!"PAID".equals(pgInfo.status()) || pgInfo.totalAmount() != ctx.totalPaymentPrice()) {
-            String failReason = "PG상태: " + pgInfo.status() +
-                    ", 예상금액: " + ctx.totalPaymentPrice() +
-                    ", 실제금액: " + pgInfo.totalAmount();
-            try {
-                if ("PAID".equals(pgInfo.status())) {
-                    paymentProvider.cancelPayment(pgInfo.pgTransactionId(), pgInfo.totalAmount(), "금액 불일치 자동 환불");
-                }
-            } catch (Exception ex) {
-                log.warn("PG 자동취소 실패: paymentId={}", ctx.paymentId(), ex);
-            } finally {
-                self.failConfirm(ctx.paymentId(), pgInfo.pgTransactionId(), failReason);
-            }
-            throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
-        }
-
-        // 4. 결제 승인 직전 재고 확정 차감 — over-selling 방지 + 보상 트랜잭션
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "failure";
         try {
-            self.decreaseStockForConfirm(ctx.paymentId());
-        } catch (CustomException e) {
-            // PG는 이미 PAID 처리됨 → 자동 환불 보상 + Payment FAILED + 원본 에러 전파
-            String failReason = "재고 차감 실패: " + e.getErrorCode().name();
-            try {
-                paymentProvider.cancelPayment(
-                        pgInfo.pgTransactionId(),
-                        pgInfo.totalAmount(),
-                        "재고 차감 실패 자동 환불 (" + e.getErrorCode().name() + ")");
-            } catch (Exception ex) {
-                // PG 환불 자체가 실패 — 운영 알람 대상
-                log.error("[Payment] 재고 실패 후 PG 자동 환불 실패: paymentId={}, pgTxId={}, error={}",
-                        ctx.paymentId(), pgInfo.pgTransactionId(), ex.getMessage(), ex);
+            if (userId == null) {
+                throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
             }
-            self.failConfirm(ctx.paymentId(), pgInfo.pgTransactionId(), failReason);
-            log.warn("[Payment] 결제 후 재고 차감 실패: paymentId={}, errorCode={}",
-                    ctx.paymentId(), e.getErrorCode());
-            throw e; // 원본 PRODUCT_SOLD_OUT / PRODUCT_STOCK_INSUFFICIENT 그대로 전파
-        }
+            // 1. DB에서 유저와 결제 상태 확인
+            ConfirmContext ctx = self.validateForConfirm(userId, request.getPaymentId());
 
-        // 5. 최종 성공 반영
-        return self.completeConfirm(ctx.paymentId(), pgInfo, userId);
+            // 2. 외부 PG사 통신
+            PortOnePaymentInfo pgInfo = paymentProvider.getPaymentInfo(request.getPgTransactionId());
+
+            //  3. 데이터 무결성 검증 및 롤백
+            if (!"PAID".equals(pgInfo.status()) || pgInfo.totalAmount() != ctx.totalPaymentPrice()) {
+                String failReason = "PG상태: " + pgInfo.status() +
+                        ", 예상금액: " + ctx.totalPaymentPrice() +
+                        ", 실제금액: " + pgInfo.totalAmount();
+                // 금액 불일치는 보안/계산 버그 신호 — 즉시 알람 대상
+                meterRegistry.counter("myfave.payment.amount.mismatch").increment();
+                log.error("[Payment] 금액 불일치: paymentId={}, serverAmount={}, pgAmount={}, diff={}, pgStatus={}",
+                        ctx.paymentId(), ctx.totalPaymentPrice(), pgInfo.totalAmount(),
+                        pgInfo.totalAmount() - ctx.totalPaymentPrice(), pgInfo.status());
+                try {
+                    if ("PAID".equals(pgInfo.status())) {
+                        paymentProvider.cancelPayment(pgInfo.pgTransactionId(), pgInfo.totalAmount(), "금액 불일치 자동 환불");
+                        meterRegistry.counter("myfave.payment.pg.auto.refund", "outcome", "success", "trigger", "amount_mismatch").increment();
+                    }
+                } catch (Exception ex) {
+                    meterRegistry.counter("myfave.payment.pg.auto.refund", "outcome", "failure", "trigger", "amount_mismatch").increment();
+                    log.warn("PG 자동취소 실패: paymentId={}", ctx.paymentId(), ex);
+                } finally {
+                    self.failConfirm(ctx.paymentId(), pgInfo.pgTransactionId(), failReason);
+                }
+                throw new CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+            }
+
+            // 4. 결제 승인 직전 재고 확정 차감 — over-selling 방지 + 보상 트랜잭션
+            try {
+                self.decreaseStockForConfirm(ctx.paymentId());
+            } catch (CustomException e) {
+                meterRegistry.counter("myfave.payment.stock.deduct.failed",
+                        "reason", e.getErrorCode().name()).increment();
+                // PG는 이미 PAID 처리됨 → 자동 환불 보상 + Payment FAILED + 원본 에러 전파
+                String failReason = "재고 차감 실패: " + e.getErrorCode().name();
+                try {
+                    paymentProvider.cancelPayment(
+                            pgInfo.pgTransactionId(),
+                            pgInfo.totalAmount(),
+                            "재고 차감 실패 자동 환불 (" + e.getErrorCode().name() + ")");
+                    meterRegistry.counter("myfave.payment.pg.auto.refund", "outcome", "success", "trigger", "stock_deduct_failed").increment();
+                } catch (Exception ex) {
+                    meterRegistry.counter("myfave.payment.pg.auto.refund", "outcome", "failure", "trigger", "stock_deduct_failed").increment();
+                    // PG 환불 자체가 실패 — 운영 알람 대상
+                    log.error("[Payment] 재고 실패 후 PG 자동 환불 실패: paymentId={}, pgTxId={}, error={}",
+                            ctx.paymentId(), pgInfo.pgTransactionId(), ex.getMessage(), ex);
+                }
+                self.failConfirm(ctx.paymentId(), pgInfo.pgTransactionId(), failReason);
+                // 보상 분기 트리거 — WARN → ERROR 승격
+                log.error("[Payment] 결제 후 재고 차감 실패: paymentId={}, errorCode={}",
+                        ctx.paymentId(), e.getErrorCode());
+                throw e; // 원본 PRODUCT_SOLD_OUT / PRODUCT_STOCK_INSUFFICIENT 그대로 전파
+            }
+
+            // 5. 최종 성공 반영
+            PaymentResponse response = self.completeConfirm(ctx.paymentId(), pgInfo, userId);
+            outcome = "success";
+            return response;
+        } finally {
+            meterRegistry.counter("myfave.payment.confirm", "outcome", outcome).increment();
+            sample.stop(Timer.builder("myfave.payment.confirm.duration")
+                    .tag("outcome", outcome)
+                    .register(meterRegistry));
+        }
     }
 
     // 결제 승인 직전 재고 확정 차감 — over-selling 방지를 위해 PESSIMISTIC_WRITE 락 사용
@@ -350,7 +376,8 @@ public class PaymentService {
                             e.getMessage());
                 } catch (Exception compensationEx) {
                     // 보상 트랜잭션 자체가 실패해도 PG 환불은 이미 완료된 상태이므로
-                    // 운영 추적이 가능하도록 ERROR 로그를 반드시 남긴다.
+                    // 운영 추적이 가능하도록 ERROR 로그를 반드시 남긴다. 수동 복구 큐 대상.
+                    meterRegistry.counter("myfave.payment.compensation.persist.failed").increment();
                     log.error("[Payment] PG 환불 완료 + 재고 복구 실패 + 보상 영속화까지 실패: "
                                     + "paymentId={}, pgTxId={}, cancelAmount={}, compensationError={}",
                             ctx.paymentId(), ctx.pgTransactionId(), ctx.cancelAmount(),
@@ -417,6 +444,8 @@ public class PaymentService {
                 try {
                     product.increaseStock(1);
                 } catch (CustomException e) {
+                    // 데이터 불일치 위험 — 즉시 알람 + 보상 영속화 트리거
+                    meterRegistry.counter("myfave.payment.stock.restore.failed").increment();
                     throw new CustomException(ErrorCode.PAYMENT_STOCK_RESTORE_FAILED);
                 }
             }
@@ -631,11 +660,16 @@ public class PaymentService {
             mac.init(new SecretKeySpec(apiSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
             String computed = Base64.getEncoder().encodeToString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)));
             if (!computed.equals(signature)) {
+                // 공격/설정 오류 신호 — 즉시 알람 대상
+                meterRegistry.counter("myfave.payment.webhook.signature.invalid", "reason", "mismatch").increment();
+                log.warn("[Webhook] 서명 검증 실패: webhookId={}, reason=mismatch", webhookId);
                 throw new CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID_SIGNATURE);
             }
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
+            meterRegistry.counter("myfave.payment.webhook.signature.invalid", "reason", "exception").increment();
+            log.warn("[Webhook] 서명 검증 예외: webhookId={}, error={}", webhookId, e.getMessage());
             throw new CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID_SIGNATURE);
         }
     }

--- a/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
@@ -37,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -273,9 +274,29 @@ public class PaymentService {
                 .toList();
 
         for (Long pid : sortedProductIds) {
-            Product product = productRepository.findByIdForUpdate(pid)
-                    .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-            product.decreaseStock(1); // stockQuantity-- + isSoldout 동기화
+            // 락 획득 대기시간 측정 — PESSIMISTIC_WRITE 경합 강도 시나리오 D 검증
+            Timer.Sample lockSample = Timer.start(meterRegistry);
+            Product product;
+            try {
+                product = productRepository.findByIdForUpdate(pid)
+                        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+            } catch (PessimisticLockingFailureException e) {
+                // 데드락/락 타임아웃 (Hibernate가 Spring DataAccessException으로 변환).
+                // PostgreSQL deadlock_timeout(기본 1s) 초과나 40P01 발생 시 진입.
+                meterRegistry.counter("myfave.stock.deadlock").increment();
+                meterRegistry.counter("myfave.stock.deduct.attempt", "outcome", "deadlock").increment();
+                throw e;
+            } finally {
+                lockSample.stop(Timer.builder("myfave.stock.lock.wait.duration").register(meterRegistry));
+            }
+            try {
+                product.decreaseStock(1); // stockQuantity-- + isSoldout 동기화
+                meterRegistry.counter("myfave.stock.deduct.attempt", "outcome", "success").increment();
+            } catch (CustomException e) {
+                String outcome = ErrorCode.PRODUCT_SOLD_OUT.equals(e.getErrorCode()) ? "sold_out" : "insufficient";
+                meterRegistry.counter("myfave.stock.deduct.attempt", "outcome", outcome).increment();
+                throw e;
+            }
         }
     }
 

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -39,4 +39,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Product p where p.productId = :productId and p.deletedAt is null")
     Optional<Product> findByIdForUpdate(@Param("productId") Long productId);
+
+    // myfave.stock.snapshot: 부하테스트 시드 상품(reset.sql 기준 productId 1~10) 재고 합계 Gauge용
+    @Query("select coalesce(sum(p.stockQuantity), 0) from Product p where p.productId in :productIds")
+    long sumStockQuantityByProductIds(@Param("productIds") List<Long> productIds);
 }

--- a/backend/src/main/java/com/myfave/api/global/config/MetricsConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/MetricsConfig.java
@@ -1,10 +1,15 @@
 package com.myfave.api.global.config;
 
+import com.myfave.api.domain.payment.entity.PaymentStatus;
+import com.myfave.api.domain.payment.repository.PaymentRepository;
+import com.myfave.api.domain.product.repository.ProductRepository;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import jakarta.annotation.PostConstruct;
+
+import java.util.List;
 
 /**
  * 커스텀 비즈니스 메트릭 등록 설정.
@@ -12,13 +17,21 @@ import jakarta.annotation.PostConstruct;
  *
  * 노출되는 메트릭:
  * - myfave_websocket_sessions_active: 현재 활성 WebSocket 세션 수 (모든 채팅방 합산)
+ * - myfave_payment_pending_gauge: 현재 PENDING 결제 건수 (Reconciliation 적체 관측)
+ * - myfave_stock_snapshot: 부하테스트 시드 상품 재고 합계 (시나리오 D over-selling 검증)
  */
 @Configuration
 @RequiredArgsConstructor
 public class MetricsConfig {
 
+    // 부하테스트 시드 상품 ID (load-test/seed/reset.sql과 동기화 — productId BETWEEN 1 AND 10)
+    private static final List<Long> LOADTEST_TARGET_PRODUCT_IDS =
+            List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+
     private final MeterRegistry meterRegistry;
     private final SessionRegistry sessionRegistry;
+    private final PaymentRepository paymentRepository;
+    private final ProductRepository productRepository;
 
     @PostConstruct
     public void registerMetrics() {
@@ -26,6 +39,17 @@ public class MetricsConfig {
         // 모든 채팅방의 세션 수 합. 시나리오 E (라이브 채팅 1000명 동시 접속) 검증용.
         Gauge.builder("myfave.websocket.sessions.active", sessionRegistry, this::totalActiveSessions)
                 .description("현재 활성 WebSocket 세션 수 (모든 채팅방 합산)")
+                .register(meterRegistry);
+
+        // PENDING 결제 적체량 — Reconciliation 정상성 + 결제 적체 알람
+        Gauge.builder("myfave.payment.pending.gauge", paymentRepository, this::countPendingPayments)
+                .description("현재 PENDING 상태 결제 건수")
+                .register(meterRegistry);
+
+        // 부하테스트 시드 상품 재고 합계 — 시나리오 D over-selling 검증의 SOT
+        // start_stock − end_stock 이 결제 성공 카운터와 정확히 일치해야 함
+        Gauge.builder("myfave.stock.snapshot", productRepository, this::sumLoadtestStock)
+                .description("부하테스트 시드 상품(productId 1~10) 재고 합계")
                 .register(meterRegistry);
     }
 
@@ -37,5 +61,13 @@ public class MetricsConfig {
         // 현재 SessionRegistry는 roomId별 카운트만 제공하므로, 합산 로직을 여기 둠
         // (불변성 유지를 위해 SessionRegistry 코드를 안 건드림)
         return registry.totalActiveSessions();
+    }
+
+    private double countPendingPayments(PaymentRepository repo) {
+        return repo.countByPaymentStatus(PaymentStatus.PENDING);
+    }
+
+    private double sumLoadtestStock(ProductRepository repo) {
+        return repo.sumStockQuantityByProductIds(LOADTEST_TARGET_PRODUCT_IDS);
     }
 }

--- a/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/myfave/api/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.myfave.api.global.error;
 
 import com.myfave.api.global.common.ApiResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,11 +14,15 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final MeterRegistry meterRegistry;
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
+        countError(errorCode.name(), errorCode.getHttpStatus());
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode));
@@ -24,6 +30,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        countError("VALIDATION_INVALID", 400);
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .findFirst()
@@ -35,6 +42,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+        countError(ErrorCode.COMMON_METHOD_NOT_ALLOWED.name(), 405);
         return ResponseEntity
                 .status(405)
                 .body(ApiResponse.error(ErrorCode.COMMON_METHOD_NOT_ALLOWED));
@@ -42,6 +50,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        countError("MESSAGE_NOT_READABLE", 400);
         String message = e.getCause() != null ? e.getCause().getMessage() : ErrorCode.COMMON_INVALID_INPUT.getMessage();
         return ResponseEntity
                 .status(400)
@@ -50,6 +59,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingServletRequestPartException.class)
     public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestPart(MissingServletRequestPartException e) {
+        countError("MISSING_REQUEST_PART", 400);
         return ResponseEntity
                 .status(400)
                 .body(new ApiResponse<>(400, "필수 파일 파라미터가 누락되었습니다.", null));
@@ -57,9 +67,18 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        countError("UNHANDLED", 500);
         log.error("Unhandled exception: {}", e.getMessage(), e);
         return ResponseEntity
                 .status(500)
                 .body(ApiResponse.error(ErrorCode.COMMON_INTERNAL_ERROR));
+    }
+
+    // ErrorCode.name()은 enum이라 유한(<60). VALIDATION_INVALID 등 식별자도 상수.
+    // 카디널리티 안전 — Prometheus 라벨로 안전하게 사용 가능.
+    private void countError(String code, int httpStatus) {
+        meterRegistry.counter("myfave.error.thrown",
+                "code", code,
+                "http_status", String.valueOf(httpStatus)).increment();
     }
 }

--- a/backend/src/main/java/com/myfave/api/global/filter/TraceIdFilter.java
+++ b/backend/src/main/java/com/myfave/api/global/filter/TraceIdFilter.java
@@ -17,6 +17,15 @@ public class TraceIdFilter extends OncePerRequestFilter {
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
     private static final String MDC_KEY = "trace_id";
 
+    // k6 부하테스트 라운드/시나리오 라벨 — Loki에서 Round별 로그 분리용.
+    // k6 lib/context.js에서 모든 요청에 자동 부착됨.
+    private static final String LOADTEST_RUN_ID_HEADER = "X-Loadtest-Run-Id";
+    private static final String LOADTEST_SCENARIO_HEADER = "X-Loadtest-Scenario";
+    private static final String LOADTEST_ROUND_HEADER = "X-Loadtest-Round";
+    private static final String MDC_LOADTEST_RUN_ID = "loadtest_run_id";
+    private static final String MDC_LOADTEST_SCENARIO = "loadtest_scenario";
+    private static final String MDC_LOADTEST_ROUND = "loadtest_round";
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
@@ -26,10 +35,26 @@ public class TraceIdFilter extends OncePerRequestFilter {
         }
         MDC.put(MDC_KEY, traceId);
         response.setHeader(TRACE_ID_HEADER, traceId);
+
+        // 부하테스트 헤더가 있을 때만 MDC에 주입 — 운영 트래픽에는 무영향.
+        putIfPresent(request, LOADTEST_RUN_ID_HEADER, MDC_LOADTEST_RUN_ID);
+        putIfPresent(request, LOADTEST_SCENARIO_HEADER, MDC_LOADTEST_SCENARIO);
+        putIfPresent(request, LOADTEST_ROUND_HEADER, MDC_LOADTEST_ROUND);
+
         try {
             filterChain.doFilter(request, response);
         } finally {
             MDC.remove(MDC_KEY);
+            MDC.remove(MDC_LOADTEST_RUN_ID);
+            MDC.remove(MDC_LOADTEST_SCENARIO);
+            MDC.remove(MDC_LOADTEST_ROUND);
+        }
+    }
+
+    private void putIfPresent(HttpServletRequest request, String headerName, String mdcKey) {
+        String value = request.getHeader(headerName);
+        if (value != null && !value.isBlank()) {
+            MDC.put(mdcKey, value);
         }
     }
 }

--- a/backend/src/main/resources/application-loadtest.yml
+++ b/backend/src/main/resources/application-loadtest.yml
@@ -14,6 +14,8 @@ spring:
       hibernate:
         format_sql: false
         default_batch_fetch_size: 100
+        # 500ms 초과 쿼리만 SQL_SLOW 로거로 출력 — slow query 분포 + Loki LogQL 검색용
+        session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 500
 
   data:
     redis:
@@ -91,3 +93,8 @@ management:
   metrics:
     tags:
       application: myfave-api-loadtest
+
+# Hibernate slow query 로깅 — Round별 비교 + slow query 분포 측정
+logging:
+  level:
+    org.hibernate.SQL_SLOW: INFO

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,6 +8,10 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: false
+    properties:
+      hibernate:
+        # 1000ms 초과 쿼리만 운영 로그로 (loadtest 500ms 보다 보수적 — 로그 폭주 방지)
+        session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 1000
 
   data:
     redis:
@@ -17,6 +21,11 @@ spring:
 springdoc:
   swagger-ui:
     enabled: false
+
+# 운영에서도 slow query 인지 가능하도록 SQL_SLOW 로거 INFO 유지
+logging:
+  level:
+    org.hibernate.SQL_SLOW: INFO
 
 # CORS 설정 (prod profile override)
 app:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+        # Round 0~3 비교용 — 라운드별 총 쿼리 수/페치 횟수 메트릭 노출
+        # (hibernate_statistics_query_executions_total 등). overhead 1~3%.
+        generate_statistics: true
 
 server:
   port: 8080

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] traceId=%X{trace_id:-no-trace} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] traceId=%X{trace_id:-no-trace} loadtest=%X{loadtest_scenario:-}:%X{loadtest_round:-}:%X{loadtest_run_id:-} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -9,6 +9,7 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus-alerts.yml:/etc/prometheus/prometheus-alerts.yml:ro
     networks:
       - myfave-network
     restart: unless-stopped

--- a/observability/grafana/provisioning/dashboards/myfave-errors.json
+++ b/observability/grafana/provisioning/dashboards/myfave-errors.json
@@ -1,0 +1,143 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisPlacement": "auto", "orientation": "horizontal", "barWidth": 0.97},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 11, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {"displayMode": "hidden", "placement": "bottom", "showLegend": false},
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {"mode": "single", "sort": "none"},
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "topk(10, sum by (code) (increase(myfave_error_thrown_total[1h])))",
+          "legendFormat": "{{code}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 ErrorCode 분포 (1h)",
+      "type": "barchart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "stacking": {"group": "A", "mode": "normal"}},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 11, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (http_status) (rate(myfave_error_thrown_total[1m]))",
+          "legendFormat": "{{http_status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate by HTTP Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 11},
+      "id": 3,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"myfave-api\",status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"myfave-api\"}[1m])), 1e-9)",
+          "legendFormat": "5xx rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 5xx Error Rate (전체)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 1},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 11},
+      "id": 4,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "topk(10, sum by (uri) (rate(http_server_requests_seconds_count{application=\"myfave-api\",status=~\"5..\"}[5m])))",
+          "legendFormat": "{{uri}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 URI by 5xx Rate",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": ["myfave", "errors"],
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MyFave — Errors & ErrorCodes",
+  "uid": "myfave-errors",
+  "version": 1
+}

--- a/observability/grafana/provisioning/dashboards/myfave-loadtest-rounds.json
+++ b/observability/grafana/provisioning/dashboards/myfave-loadtest-rounds.json
@@ -1,0 +1,208 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(k6_http_req_duration_seconds_bucket{scenario=~\"$scenario\",round=~\"$round\"}[1m])) by (le, round))",
+          "legendFormat": "Round {{round}} p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 HTTP Duration p95 (라운드 비교)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (round) (rate(k6_http_reqs_total{scenario=~\"$scenario\",round=~\"$round\"}[1m]))",
+          "legendFormat": "Round {{round}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 HTTP TPS (라운드 비교)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 10},
+      "id": 3,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["last", "max"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "k6_vus{scenario=~\"$scenario\",round=~\"$round\"}",
+          "legendFormat": "Round {{round}} VUs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 Virtual Users (라운드 비교)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "stacking": {"group": "A", "mode": "none"}},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 10},
+      "id": 4,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (round) (rate(k6_http_req_failed_total{scenario=~\"$scenario\",round=~\"$round\"}[1m]))",
+          "legendFormat": "Round {{round}} failed/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 Failed Requests Rate (라운드 비교)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 20},
+      "id": 5,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(hibernate_statistics_query_executions_total[1m])",
+          "legendFormat": "queries/s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(hibernate_statistics_entity_fetches_total[1m])",
+          "legendFormat": "entity fetches/s",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Hibernate Query/Fetch Rate (Round 비교 — k6 라벨과 시각 매칭)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 42,
+  "tags": ["myfave", "loadtest", "rounds"],
+  "templating": {
+    "list": [
+      {
+        "current": {"text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(k6_http_reqs_total, scenario)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "scenario",
+        "multi": true,
+        "name": "scenario",
+        "options": [],
+        "query": {"query": "label_values(k6_http_reqs_total, scenario)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {"text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(k6_http_reqs_total{scenario=~\"$scenario\"}, round)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "round",
+        "multi": true,
+        "name": "round",
+        "options": [],
+        "query": {"query": "label_values(k6_http_reqs_total{scenario=~\"$scenario\"}, round)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MyFave — Loadtest Round 비교 (R0→R3)",
+  "uid": "myfave-loadtest-rounds",
+  "version": 1
+}

--- a/observability/grafana/provisioning/dashboards/myfave-payment.json
+++ b/observability/grafana/provisioning/dashboards/myfave-payment.json
@@ -1,0 +1,279 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.99},
+              {"color": "green", "value": 0.995}
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(rate(myfave_payment_confirm_total{outcome=\"success\"}[5m])) / clamp_min(sum(rate(myfave_payment_confirm_total[5m])), 1e-9)",
+          "legendFormat": "success rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Confirm Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 50},
+              {"color": "red", "value": 200}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "myfave_payment_pending_gauge",
+          "legendFormat": "PENDING",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Payments",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "increase(myfave_payment_amount_mismatch_total[1h])",
+          "legendFormat": "1h",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Amount Mismatch (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(myfave_payment_confirm_duration_seconds_bucket[5m])) by (le, outcome))",
+          "legendFormat": "p95 outcome={{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Confirm Duration p95 (by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(myfave_portone_call_duration_seconds_bucket[5m])) by (le, api))",
+          "legendFormat": "p95 api={{api}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PortOne PG Call Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 17},
+      "id": 6,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(myfave_payment_stock_deduct_failed_total[1m])",
+          "legendFormat": "stock.deduct.failed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(myfave_payment_pg_auto_refund_total[1m])",
+          "legendFormat": "pg.auto.refund {{outcome}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(myfave_payment_stock_restore_failed_total[1m])",
+          "legendFormat": "stock.restore.failed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(myfave_payment_compensation_persist_failed_total[1m])",
+          "legendFormat": "compensation.persist.failed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Saga Compensation Events (rate/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 17},
+      "id": 7,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (api, status_class) (rate(myfave_portone_http_errors_total[1m]))",
+          "legendFormat": "{{api}} {{status_class}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PortOne HTTP Errors (by api/status_class)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": ["myfave", "payment"],
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MyFave — Payment Saga",
+  "uid": "myfave-payment",
+  "version": 1
+}

--- a/observability/grafana/provisioning/dashboards/myfave-stock.json
+++ b/observability/grafana/provisioning/dashboards/myfave-stock.json
@@ -1,0 +1,272 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "green", "value": 5}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "myfave_stock_snapshot",
+          "legendFormat": "잔여 재고 합계",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Snapshot (시드 상품 1~10 합계)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "increase(myfave_stock_deadlock_total[15m])",
+          "legendFormat": "15m",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Deadlock (15m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 100}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(increase(myfave_stock_deduct_attempt_total{outcome=\"success\"}[15m]))",
+          "legendFormat": "성공 차감 15m",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "재고 성공 차감 (15m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 8},
+      "id": 4,
+      "options": {
+        "displayLabels": ["name", "percent"],
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"]},
+        "pieType": "donut",
+        "reduceOptions": {"calcs": ["sum"], "fields": "", "values": false},
+        "tooltip": {"mode": "single", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (outcome) (increase(myfave_stock_deduct_attempt_total[15m]))",
+          "legendFormat": "{{outcome}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Deduct Outcome 분포 (15m)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 8},
+      "id": 5,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(myfave_stock_lock_wait_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(myfave_stock_lock_wait_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(myfave_stock_lock_wait_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Stock Lock Wait Duration p50/p95/p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "stacking": {"group": "A", "mode": "normal"}},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 17},
+      "id": 6,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (outcome) (rate(myfave_stock_deduct_attempt_total[1m]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Deduct Attempt Rate (by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 17},
+      "id": 7,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "rate(myfave_stock_deadlock_total[1m])",
+          "legendFormat": "deadlock/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stock Deadlock Rate",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "10s",
+  "schemaVersion": 42,
+  "tags": ["myfave", "stock", "loadtest-D"],
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MyFave — Stock & Concurrency (시나리오 D)",
+  "uid": "myfave-stock",
+  "version": 1
+}

--- a/observability/prometheus-alerts.yml
+++ b/observability/prometheus-alerts.yml
@@ -1,0 +1,82 @@
+groups:
+  # 결제·재고 데이터 불일치/금전 손실 직결 — 즉시 알람 대상 (critical)
+  - name: myfave.payment.critical
+    interval: 30s
+    rules:
+      - alert: PaymentAmountMismatch
+        expr: increase(myfave_payment_amount_mismatch_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          domain: payment
+        annotations:
+          summary: "결제 금액 불일치 감지"
+          description: "최근 5분간 서버 계산금액 ≠ PG 금액 발생. 보안/계산 버그 또는 외부 PG 응답 이상."
+
+      - alert: WebhookSignatureInvalid
+        expr: increase(myfave_payment_webhook_signature_invalid_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          domain: payment
+        annotations:
+          summary: "PortOne 웹훅 서명 검증 실패"
+          description: "공격 또는 PORTONE_API_SECRET 설정 오류 가능성. 즉시 조사."
+
+      - alert: StockRestoreFailed
+        expr: increase(myfave_payment_stock_restore_failed_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          domain: payment
+        annotations:
+          summary: "결제 취소 시 재고 복구 실패"
+          description: "PG 환불은 완료됐으나 재고가 복구되지 않음. 데이터 불일치 — 수동 복구 필요."
+
+      - alert: CompensationPersistFailed
+        expr: increase(myfave_payment_compensation_persist_failed_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          domain: payment
+        annotations:
+          summary: "결제 보상 트랜잭션 영속화 실패"
+          description: "PG 환불 + 재고 복구 모두 실패 후 보상 기록까지 실패. 즉시 수동 복구 큐 처리."
+
+  # 비정상은 아니나 가시화 필요한 이벤트 (warning)
+  - name: myfave.payment.warning
+    interval: 30s
+    rules:
+      - alert: PgAutoRefundOccurred
+        expr: increase(myfave_payment_pg_auto_refund_total[10m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          domain: payment
+        annotations:
+          summary: "PG 자동환불 발생"
+          description: "금액 불일치 또는 재고 차감 실패로 자동환불 진행. 빈도 추적 필요."
+
+      - alert: PaymentPendingBacklog
+        expr: myfave_payment_pending_gauge > 50
+        for: 10m
+        labels:
+          severity: warning
+          domain: payment
+        annotations:
+          summary: "PENDING 결제 적체"
+          description: "PENDING 결제 50건 이상 10분 지속. Reconciliation 스케줄러 또는 PG 응답 지연 의심."
+
+  # 재고 동시성 — 시나리오 D 부하테스트 중 모니터링 + 운영 데드락 감지
+  - name: myfave.stock
+    interval: 30s
+    rules:
+      - alert: StockDeadlockSpike
+        expr: rate(myfave_stock_deadlock_total[1m]) > 0.1
+        for: 2m
+        labels:
+          severity: warning
+          domain: stock
+        annotations:
+          summary: "재고 차감 데드락 급증"
+          description: "PESSIMISTIC_WRITE 락 경합으로 데드락 발생률 0.1/s 초과. 매진 경쟁 상품 또는 락 순서 위반 의심."

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/prometheus-alerts.yml
+
 scrape_configs:
   - job_name: 'myfave-api'
     metrics_path: '/api/v1/actuator/prometheus'


### PR DESCRIPTION
⏺ 📌 관련 이슈

  Closes #170

  📝 작업 내용

  5/25 라이브 이벤트 대비, 주문/결제/재고 도메인의 P0 관찰성을 일괄 보강했습니다. 결제 Saga
  보상 흐름·재고 동시성(over-selling)·외부 PG 호출·전역 에러를 메트릭/로그/알람으로 모두 추적할
   수 있게 하고, 부하테스트 Round 0~3 비교용 k6 라벨 표준화와 Grafana 대시보드 4종을
  추가했습니다.

  총 23개 커밋 / 23개 파일 변경. 모두 파일 단위 커밋(태그: [파일명] 작업 내용)으로 분할되어
  있어 리뷰가 용이합니다.

  🔍 변경 사항

  - 기능 추가 (메트릭·로그·알람·대시보드 instrumentation)
  - 버그 수정
  - 리팩토링 (PortOnePaymentProvider 호출 패턴 Timer/Counter 래핑)
  - 테스트 추가 / 수정
  - 문서 수정
  - 기타 (Prometheus alert rule 신규, Grafana 대시보드 4종 신규, k6 부하테스트 라벨 표준화)

  💡 구현 방법 / 주요 변경 포인트

  도메인별 변경 (코드 패키지 기준)

  영역: domain/payment/service
  파일: PaymentService.java (2회)
  핵심 변경: 결제 Confirm Counter/Timer + Saga 보상 5종 카운터(amount.mismatch,
    stock.deduct.failed, pg.auto.refund, stock.restore.failed, compensation.persist.failed,
    webhook.signature.invalid) + 재고 차감 루프에 락 대기 Timer/데드락 Counter + 금액불일치
    ERROR 로그 신규, 재고 차감 실패 WARN→ERROR 승격
  ────────────────────────────────────────
  영역: domain/payment/provider
  파일: PortOnePaymentProvider.java
  핵심 변경: invokeWithMetrics Supplier 헬퍼로 PG 호출 전체 감싸기 —
    myfave.portone.call.duration{api,outcome} Timer + http.errors{api,status_class} Counter +
    호출 로그 신규
  ────────────────────────────────────────
  영역: domain/payment/repository
  파일: PaymentRepository.java
  핵심 변경: countByPaymentStatus (PENDING Gauge 용)
  ────────────────────────────────────────
  영역: domain/order/service
  파일: OrderService.java
  핵심 변경: @Slf4j 추가(기존 로그 0건) + 주문 생성/구매확정/취소 INFO 로그 +
    order.created/status.transition Counter
  ────────────────────────────────────────
  영역: domain/product/repository
  파일: ProductRepository.java
  핵심 변경: sumStockQuantityByProductIds (재고 스냅샷 Gauge 용)
  ────────────────────────────────────────
  영역: global/config
  파일: MetricsConfig.java
  핵심 변경: myfave.payment.pending.gauge + myfave.stock.snapshot Gauge 등록 (기존
    @PostConstruct 패턴 재사용)
  ────────────────────────────────────────
  영역: global/error
  파일: GlobalExceptionHandler.java
  핵심 변경: MeterRegistry 주입 + myfave.error.thrown{code,http_status} 모든 핸들러에서 증가
    (CustomException + 표준 예외 5종)
  ────────────────────────────────────────
  영역: global/filter
  파일: TraceIdFilter.java
  핵심 변경: X-Loadtest-Run-Id/Scenario/Round 헤더 MDC 주입 (운영 트래픽 무영향, finally에서
    remove)
  ────────────────────────────────────────
  영역: resources
  파일: application.yml, -loadtest.yml, -prod.yml, logback-spring.xml
  핵심 변경: hibernate.generate_statistics=true(공통), slow SQL 임계값(loadtest 500ms / prod
    1000ms), logback 패턴에 loadtest_scenario:round:run_id 추가
  ────────────────────────────────────────
  영역: observability
  파일: prometheus-alerts.yml(신규), prometheus.yml, docker-compose.monitoring.yml
  핵심 변경: 7개 alert rule (critical 4 + warning 3) + rule_files 등록 + Prometheus 컨테이너
    마운트
  ────────────────────────────────────────
  영역: grafana/dashboards
  파일: myfave-payment.json (신규), myfave-stock.json(신규), myfave-errors.json(신규),
    myfave-loadtest-rounds.json(신규)
  핵심 변경: 토픽별 대시보드 4종 동일 폴더에 추가 (총 23패널)
  ────────────────────────────────────────
  영역: load-test/k6/lib
  파일: context.js(신규), http.js, stomp.js
  핵심 변경: LOADTEST_* 환경변수 → 헤더/태그 헬퍼, HTTP/STOMP 양쪽에 자동 부착
  
  설계 결정

  1. 카디널리티 안전성 — code(ErrorCode enum, <60), outcome(success/failure/sold_out/...),
  api(getPaymentInfo/cancelPayment) 만 라벨로. productId·userId·orderId는 라벨 X (로그 MDC로만
  노출).
  2. MeterRegistry 주입 패턴 — 기존 ChatMessageController:81 Counter / RedisSubscriber:36 Timer
   패턴 그대로 재사용. 신규 패턴 도입 없음.
  3. Gauge 데이터 소스 — MetricsConfig가 Repository를 직접 호출 (15초 scrape마다 가벼운
  COUNT/SUM 쿼리). payment_status 인덱스와 PK 범위 스캔으로 비용 무시 수준.
  4. 부하테스트 시드 상품 ID — MetricsConfig.LOADTEST_TARGET_PRODUCT_IDS = List.of(1L..10L)
  코드 상수. load-test/seed/reset.sql의 BETWEEN 1 AND 10과 동기화 필요 (주석 명시).
  5. Order 상태 전이 카운터 위치 — 도메인 이벤트가 깔끔하지만 라이브 직전 리팩토링 위험. 호출부
   카운팅(OrderService 메서드 안)만 P0로 채택. Order.completePay()/refund() 같은 PaymentService
   호출분은 P1로 미룸.
  6. generate_statistics prod 적용 — 사용자 요청대로 loadtest/prod 동일 적용. 1~3% overhead
  있으므로 5/25 이후 1주 모니터링 후 결정. 1라인 롤백 가능.
  7. Saga 보상 Counter 위치 — 기존 try-catch 분기를 재사용해서 outcome=success|failure ×
  trigger=amount_mismatch|stock_deduct_failed 두 태그로 분리. PG 자동환불 발생 원인을
  메트릭으로 분류 가능.

  ✅ 테스트 방법

  1. 환경 설정

  # .env 확인 (GRAFANA_PASSWORD 필수)
  cat .env | grep GRAFANA_PASSWORD

  # 인프라 기동
  docker-compose up -d
  docker-compose -f docker-compose.monitoring.yml up -d

  2. 실행 방법

  (A) 컴파일 검증
  cd backend && ./gradlew build -x test
  
  ▎ 메모리 노트: Gradle 8.11 + Java 25 비호환 가능. 실패 시 JAVA_HOME=$(/usr/libexec/java_home 
  ▎ -v 21) 확인.

  (B) 백엔드 기동 (loadtest 프로필)
  cd backend && SPRING_PROFILES_ACTIVE=loadtest ./gradlew bootRun
  
  (C) 메트릭 노출 확인
  curl -s http://localhost:8080/api/v1/actuator/prometheus | grep -E
  "myfave_(payment|stock|order|portone|error|websocket)_"
  
  (D) 부하테스트 1회 (시나리오 D, Round 0)
  LOADTEST_RUN_ID="2026-05-25T18-D-r0" \
  LOADTEST_SCENARIO="D" \
  LOADTEST_ROUND="0" \
  k6 run backend/load-test/k6/scenarios/D-*.js

  3. 확인 사항

  - /actuator/prometheus 응답에 신규 메트릭 16개 시리즈 모두 노출
  - Prometheus UI(http://localhost:9090/alerts)에서 알람 룰 7개 LOADED 상태
  - Grafana(http://localhost:3000)에서 신규 대시보드 4종 자동 인식 (Dashboards → Browse에서
  myfave-payment, myfave-stock, myfave-errors, myfave-loadtest-rounds 발견)
  - over-selling 검증: MyFave — Stock & Concurrency 대시보드에서 부하테스트 종료 후
    - Stock Snapshot 시작 10 → 종료 5 (5명만 성공)
    - 재고 성공 차감 15m Stat == 5
    - 두 값의 합이 10이면 over-selling 없음
  - 금액 불일치 알람: PortOne mock에서 의도적으로 다른 금액 응답 → PaymentAmountMismatch 알람
  firing
  - 부하테스트 라벨: MyFave — Loadtest Round 비교 대시보드의 $scenario/$round 변수에서 D/0 선택
   가능
  - Loki 로그: {container="myfave-app"} | json | loadtest_scenario="D" 쿼리로 부하테스트 로그만
   분리 조회 가능

  📸 스크린샷 (선택)
  
  부하테스트 Round 0 실행 후 다음 캡처 첨부 예정:
  - MyFave — Stock & Concurrency — over-selling 0건 검증 (Stock Snapshot Stat + Outcome Donut)
  - MyFave — Payment Saga — Saga Compensation Events 패널의 보상 분기 발화
  - Prometheus /alerts — 7개 룰 LOADED 상태

  ⚠️ 리뷰어에게 전달 사항

  1. MetricsConfig.LOADTEST_TARGET_PRODUCT_IDS 코드 상수 vs yml 외부화 — 단순성을 위해 상수로
  처리했습니다. reset.sql의 BETWEEN 1 AND 10과 동기화 필요한데, 두 곳을 같이 손대야 하는 게
  부담스러우면 application.yml로 빼는 게 나을 수 있습니다. 의견 부탁드립니다.
  2. hibernate.generate_statistics=true 의 prod 적용 — 사용자 요청(loadtest+prod 동일)에 따라
  켰지만 1~3% overhead가 있습니다. 5/25 이후 1주 모니터링 후 끄는 1라인 롤백 PR을 별도로
  따겠습니다.
  3. PaymentService.decreaseStockForConfirm의 데드락 catch —
  PessimisticLockingFailureException만 잡고 throw e로 재전파합니다. confirmPayment 호출부에서는
   CustomException만 catch하므로 데드락은 그대로 500으로 응답됩니다. 매진 경쟁 시 데드락이
  잦으면 호출부에서 재시도 정책을 추가하는 게 좋을지 의견 부탁드립니다.
  4. GlobalExceptionHandler의 MeterRegistry 주입 — @RequiredArgsConstructor 추가했는데 기존
  @RestControllerAdvice + 필드 없음 패턴이 깨집니다. 의도된 변경이고 다른 곳에는 영향이 없지만,
   컨벤션 차원에서 검토 부탁드립니다.
  5. PortOnePaymentProvider의 Supplier 패턴 — 두 메서드(getPaymentInfo, cancelPayment) 공통
  wrapping을 위해 invokeWithMetrics<T> 헬퍼를 도입했습니다. cancelPayment는 void라 return 
  null로 처리되어 약간 어색할 수 있는데, 메서드 두 개에 동일 Timer 패턴 반복하는 것보다
  가독성이 낫다고 판단했습니다.
  6. 테스트 부재 — 관찰성 추가는 통합 환경에서 메트릭/알람 발화로 검증하는 게 정확합니다. JUnit
   단위 테스트는 작성하지 않았습니다. 위 "테스트 방법" 절차로 머지 전 통합 검증 부탁드립니다.

  📋 셀프 체크리스트
  
  - 코드 컨벤션을 준수했나요? (기존 Counter/Timer 패턴, MDC, ErrorCode 매핑 일관성 유지)
  - 불필요한 주석/로그를 제거했나요? (디버그 로그 DEBUG 레벨로, 핵심 보상 분기는 ERROR 승격)
  - 테스트를 작성/업데이트했나요? — 미작성 (위 "리뷰어 전달" 6번 참고)
  - PR 제목이 명확한가요? — [FEAT] 주문/결제/재고 P0 관찰성 — 메트릭·로그·알람·대시보드 일괄 
  추가