### PR TITLE
fix: 시나리오 E WebSocket 연결 실패 원인 3종 수정

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-e-chat.js
+++ b/backend/load-test/k6/scenarios/scenario-e-chat.js
@@ -16,7 +16,12 @@ import { Counter, Trend } from 'k6/metrics';
 import { connect, subscribe, send, disconnect, frameCommand } from '../lib/stomp.js';
 import { tokens } from '../lib/pool.js';
 
-const WS_URL = __ENV.WS_URL || 'ws://localhost:8080/ws';
+function sockJsWsUrl(base) {
+  const server = String(Math.floor(Math.random() * 999)).padStart(3, '0');
+  const session = Array.from({length: 8}, () => Math.random().toString(36)[2]).join('');
+  return `${base}/${server}/${session}/websocket`;
+}
+const WS_URL = sockJsWsUrl(__ENV.WS_URL || 'ws://localhost:8080/ws');
 const ROOM_ID = __ENV.ROOM_ID || '1';
 const SESSION_DURATION_MS = 4 * 60 * 1000 + 30 * 1000; // 4분 30초
 
@@ -80,9 +85,12 @@ export default function () {
           const intervalMs = isInfluencer ? 10_000 : randomBetween(3_000, 7_000);
           publishTimer = socket.setInterval(() => {
             const body = {
-              message: isInfluencer
-                ? `[host] live-msg-${Date.now()}`
-                : `[u${__VU}] hello-${__ITER}`,
+              type: 'SEND_MESSAGE',
+              payload: {
+                content: isInfluencer
+                  ? `[host] live-msg-${Date.now()}`
+                  : `[u${__VU}] hello-${__ITER}`,
+              },
             };
             socket.send(send(`/app/chat/${ROOM_ID}`, body));
             messagesSent.add(1);

--- a/backend/src/main/resources/application-loadtest.yml
+++ b/backend/src/main/resources/application-loadtest.yml
@@ -78,6 +78,8 @@ loadtest:
 
 server:
   tomcat:
+    mbeanregistry:
+      enabled: true          # Grafana Tomcat Threads 패널 메트릭 수집
     threads:
       max: 400               # 시나리오 E의 1000 WS 세션 + HTTP 동시 처리 여유
     max-connections: 2000


### PR DESCRIPTION
## Summary

- `ws://host/ws`로 SockJS 엔드포인트에 순수 WebSocket 연결을 시도해 발생하던 **4xx 에러율 99.9%** 수정 — k6가 SockJS 전송 URL 패턴(`/ws/{server}/{session}/websocket`)을 사용하도록 변경
- `ChatMessageRequest` 스키마와 불일치하던 메시지 바디(`{ message }` → `{ type, payload.content }`) 수정
- `server.tomcat.mbeanregistry.enabled: true` 추가 — Grafana Tomcat Threads 패널 미수집 문제 해결
- SockJS 세션 ID 재사용으로 인한 **376,776번 연결 루프** 수정 — `sockJsWsUrl()`을 `default function` 내부로 이동해 iteration마다 고유한 세션 ID 생성

## Root Cause (순서대로 발견)

| 순위 | 원인 | 증상 |
|---|---|---|
| 1 | SockJS 엔드포인트에 raw WebSocket 직접 접속 | 4xx 에러율 99.9% |
| 2 | STOMP 메시지 바디 스키마 불일치 | 메시지 발행 전부 실패 |
| 3 | Tomcat MBean Registry 미활성화 | Grafana 스레드 메트릭 미수집 |
| 4 | SockJS 세션 ID 재사용 | VU당 ~377회 연결 루프 (376,776 iterations) |

## Changed Files

- `backend/load-test/k6/scenarios/scenario-e-chat.js`
- `backend/src/main/resources/application-loadtest.yml`

## Test Plan

- [ ] `docker-compose up -d --build app` 으로 백엔드 재빌드
- [ ] k6 재실행: `k6 run backend/load-test/k6/scenarios/scenario-e-chat.js`
- [ ] iterations 수가 ~1,000 수준인지 확인 (이전: 376,776)
- [ ] ws_session_duration median이 4m30s 수준인지 확인 (이전: 62ms)
- [ ] Active WebSocket Sessions Grafana 패널에서 ~1,000 도달 확인