### PR TITLE
fix: 시나리오 E SockJS 세션 ID 재사용으로 인한 연결 루프 수정

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-e-chat.js
+++ b/backend/load-test/k6/scenarios/scenario-e-chat.js
@@ -16,13 +16,14 @@ import { Counter, Trend } from 'k6/metrics';
 import { connect, subscribe, send, disconnect, frameCommand } from '../lib/stomp.js';
 import { tokens } from '../lib/pool.js';
 
+const WS_BASE = __ENV.WS_URL || 'ws://localhost:8080/ws';
+const ROOM_ID = __ENV.ROOM_ID || '1';
+
 function sockJsWsUrl(base) {
   const server = String(Math.floor(Math.random() * 999)).padStart(3, '0');
   const session = Array.from({length: 8}, () => Math.random().toString(36)[2]).join('');
   return `${base}/${server}/${session}/websocket`;
 }
-const WS_URL = sockJsWsUrl(__ENV.WS_URL || 'ws://localhost:8080/ws');
-const ROOM_ID = __ENV.ROOM_ID || '1';
 const SESSION_DURATION_MS = 4 * 60 * 1000 + 30 * 1000; // 4분 30초
 
 export const options = {
@@ -50,10 +51,11 @@ const messagesSent = new Counter('chat_messages_sent');
 const subscribeTime = new Trend('chat_subscribe_ms', true);
 
 export function setup() {
-  console.log(`[scenario-E] WS_URL=${WS_URL}, ROOM_ID=${ROOM_ID}, 토큰 풀=${tokens.length}`);
+  console.log(`[scenario-E] WS_BASE=${WS_BASE}, ROOM_ID=${ROOM_ID}, 토큰 풀=${tokens.length}`);
 }
 
 export default function () {
+  const WS_URL = sockJsWsUrl(WS_BASE); // iteration마다 고유한 세션 ID 생성
   const token = tokens[(__VU - 1) % tokens.length];
   const accessToken = token.accessToken;
 


### PR DESCRIPTION
## Summary

- SockJS 세션 ID 재사용으로 인한 **376,776번 연결 루프** 수정
- `sockJsWsUrl()` 호출을 `default function` 내부로 이동해 iteration마다 고유한 세션 ID를 생성하도록 변경

## Root Cause

VU 연결 실패 후 `default function`이 재실행될 때 init context에서 생성된 동일한 `{server}/{session}` URL을 재사용했습니다. SockJS는 이미 사용된 session ID를 거부하므로 이후 모든 재시도가 62ms만에 실패 → 즉시 재시도 루프가 반복되어 376,776번의 iteration이 발생했습니다.

## Changed Files

- `backend/load-test/k6/scenarios/scenario-e-chat.js`

## Test Plan

- [ ] k6 재실행: `k6 run backend/load-test/k6/scenarios/scenario-e-chat.js`
- [ ] iterations 수가 ~1,000 수준인지 확인 (이전: 376,776)
- [ ] `ws_session_duration` median이 4m30s 수준인지 확인 (이전: 62ms)
- [ ] Active WebSocket Sessions Grafana 패널에서 ~1,000 도달 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 변경사항은 내부 로드 테스팅 인프라 업데이트로, 최종 사용자에게 영향을 주지 않습니다.

---

**참고:** WebSocket 연결 테스트 시나리오의 기술적 개선사항이 포함되어 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->