### PR TITLE
fix: 시나리오 E SockJS 프레임 포맷 불일치로 STOMP 교환 실패 수정

### DIFF
--- a/backend/load-test/k6/lib/stomp.js
+++ b/backend/load-test/k6/lib/stomp.js
@@ -1,51 +1,74 @@
 // STOMP frame 빌더 — k6/ws는 raw WebSocket만 지원하므로 STOMP 프로토콜은 수동으로 직조.
-// 백엔드: spring-boot-starter-websocket + @MessageMapping. 자세한 경로는 시나리오 E 참조.
+// 백엔드: spring-boot-starter-websocket (SockJS 엔드포인트) + @MessageMapping.
+//
+// SockJS 프레임 포맷:
+//   송신: ["<stomp-frame>"]  ← JSON 배열로 감싸서 전송
+//   수신: o                  ← open
+//         h                  ← heartbeat
+//         a["<stomp-frame>"] ← message (a 접두사 + JSON 배열)
+//         c[code,"reason"]   ← close
 
-// STOMP frame 종료자: NULL byte (0x00). String.fromCharCode로 명시적으로 생성.
 const NULL_BYTE = String.fromCharCode(0);
 
+// STOMP 프레임을 SockJS 송신 포맷으로 감싸기
+function sockJsWrap(frame) {
+  return JSON.stringify([frame]);
+}
+
 export function connect(accessToken) {
-  // Bearer 토큰은 JwtChannelInterceptor가 STOMP 헤더에서 읽음.
-  return (
+  const frame =
     'CONNECT\n' +
     'accept-version:1.2\n' +
     'host:localhost\n' +
     `Authorization:Bearer ${accessToken}\n` +
     '\n' +
-    NULL_BYTE
-  );
+    NULL_BYTE;
+  return sockJsWrap(frame);
 }
 
 export function subscribe(id, destination) {
-  return (
+  const frame =
     'SUBSCRIBE\n' +
     `id:${id}\n` +
     `destination:${destination}\n` +
     '\n' +
-    NULL_BYTE
-  );
+    NULL_BYTE;
+  return sockJsWrap(frame);
 }
 
 export function send(destination, body, contentType = 'application/json') {
   const payload = typeof body === 'string' ? body : JSON.stringify(body);
-  return (
+  const frame =
     'SEND\n' +
     `destination:${destination}\n` +
     `content-type:${contentType}\n` +
     `content-length:${payload.length}\n` +
     '\n' +
     payload +
-    NULL_BYTE
-  );
+    NULL_BYTE;
+  return sockJsWrap(frame);
 }
 
 export function disconnect() {
-  return 'DISCONNECT\n\n' + NULL_BYTE;
+  return sockJsWrap('DISCONNECT\n\n' + NULL_BYTE);
 }
 
-// 수신 메시지에서 STOMP 명령(MESSAGE/CONNECTED/ERROR) 종류 추출
+// SockJS 수신 프레임에서 STOMP 명령 추출
+// o → null(open, 무시), h → null(heartbeat, 무시)
+// a["CONNECTED\n..."] → "CONNECTED"
 export function frameCommand(raw) {
   if (typeof raw !== 'string') return null;
-  const newlineIdx = raw.indexOf('\n');
-  return newlineIdx > 0 ? raw.substring(0, newlineIdx) : raw;
+  if (raw === 'o' || raw === 'h') return null;
+  if (raw.startsWith('a[')) {
+    try {
+      const frames = JSON.parse(raw.slice(1)); // ["<stomp-frame>", ...]
+      if (!frames || frames.length === 0) return null;
+      const stomp = frames[0];
+      const newlineIdx = stomp.indexOf('\n');
+      return newlineIdx > 0 ? stomp.substring(0, newlineIdx) : stomp;
+    } catch (_) {
+      return null;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

k6 `stomp.js`가 raw STOMP 프레임을 그대로 전송해 SockJS 서버가 파싱에 실패하던 문제를 수정합니다.  
STOMP CONNECTED를 수신하지 못해 SUBSCRIBE가 전송되지 않았고, `myfave.websocket.sessions.active` 게이지가 0에 고정되었습니다.

## Root Cause

SockJS WebSocket 전송 경로(`/ws/{server}/{session}/websocket`)는 메시지를 SockJS 프레임 포맷으로 주고받아야 합니다.

| 구분 | 기존 (잘못됨) | 수정 후 |
|---|---|---|
| 송신 | `CONNECT\n...\0` (raw) | `["CONNECT\n...\0"]` (SockJS 포맷) |
| 수신 파싱 | 첫 줄 그대로 읽음 | `a[...]` 벗겨서 STOMP 명령 추출 |
| `o` / `h` 프레임 | 잘못 파싱됨 | null 반환으로 무시 |

기존에는 서버가 raw 프레임을 파싱 실패로 무시 → CONNECTED 미수신 → SUBSCRIBE 미전송 → `sessionRegistry.join()` 미호출 → 게이지 0 고정

## Changed Files

- `backend/load-test/k6/lib/stomp.js`

## Test Plan

- [ ] k6 재실행: `k6 run backend/load-test/k6/scenarios/scenario-e-chat.js`
- [ ] Grafana **Active WebSocket Sessions** 패널에 값이 올라오는지 확인
- [ ] `chat_messages_received > 0` 확인
- [ ] `ws handshake 101` 성공률 확인