### PR TITLE
fix: 시나리오 A k6 스크립트 에러율 오염 수정 및 spikeWindow 측정 로직 개선

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-a-spike.js
+++ b/backend/load-test/k6/scenarios/scenario-a-spike.js
@@ -4,9 +4,22 @@
 
 import { check, sleep } from 'k6';
 import { Trend, Counter } from 'k6/metrics';
+import http from 'k6/http';
 
 import { get, post, pickProductIdByVu, BASE_URL } from '../lib/http.js';
 import { tokens } from '../lib/pool.js';
+
+// 409(cart 중복), 404(payments/prepare orderId=0) 를 expected로 처리 — http_req_failed 임계값 오염 방지
+http.setResponseCallback(http.expectedStatuses(
+  { min: 200, max: 299 },
+  409,
+  404,
+));
+
+// 스파이크 시작 시각 (30s 예열 + 10s 스파이크 = 40초 지점)
+const TEST_START_MS = Date.now();
+const SPIKE_START_MS = 40_000;
+const SPIKE_END_MS   = 50_000;
 
 export const options = {
   scenarios: {
@@ -98,7 +111,10 @@ export default function () {
 
   // 폭증 초기 10초 구간(40~50초)의 latency만 따로 추적
   const elapsed = (Date.now() - startedAt) / 1000;
-  if (__ITER < 10) spikeWindow.add(elapsed * 1000);
+  const sinceStart = Date.now() - TEST_START_MS;
+  if (sinceStart >= SPIKE_START_MS && sinceStart < SPIKE_END_MS) {
+    spikeWindow.add(elapsed * 1000);
+  }
 
   sleep(Math.random() * 0.5);
 }


### PR DESCRIPTION
## Summary

- `http.setResponseCallback(http.expectedStatuses(...))` 추가 — 409(cart 중복), 404(payments/prepare orderId=0)를 expected로 처리해 `http_req_failed` 임계값 오염 방지
- `spikeWindow` 측정 조건을 `__ITER < 10` → 시간 기반(`sinceStart >= 40s && < 50s`)으로 교체 — 실제 스파이크 구간과 연동

## 배경

시나리오 A 2회차 부하테스트 결과, `http_req_failed < 1%` 임계값이 실제 장애 없이도 위반되는 문제 확인:
- `POST /cart-items` 409는 서버 정상 동작(중복 방지)이나 `http_req_failed`에 포함
- `POST /payments/prepare`에 `orderId: 0` 의도적 전달로 항상 404 발생
- `spikeWindow`가 VU 반복 횟수(`__ITER`) 기반이라 스파이크 구간(40~50초)과 무관

## Test plan

- [ ] 시나리오 A 재실행 후 `http_req_failed` 에러율이 실제 서버 장애 없이 1% 미만 유지되는지 확인
- [ ] Grafana `spike_first10s_latency` 트렌드가 40~50초 구간에만 기록되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Tests**
  * 성능 테스트의 레이턴시 수집 로직을 시간 기반으로 개선하여 측정 정확도를 높였습니다.
  * HTTP 상태 코드 409, 404를 예상된 응답으로 처리하도록 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->