### PR TITLE
perf: 시나리오 A Round 1 — products/coupons/orders 인덱스 추가 (Flyway V4)

### DIFF
--- a/backend/src/main/resources/db/migration/V4__add_scenario_a_round1_indexes.sql
+++ b/backend/src/main/resources/db/migration/V4__add_scenario_a_round1_indexes.sql
@@ -1,0 +1,23 @@
+-- products: soft-delete 패턴 부분 인덱스 (40% 트래픽 — GET /products/{id}, GET /products)
+CREATE INDEX IF NOT EXISTS idx_products_not_deleted
+  ON products(product_id) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_products_category_not_deleted
+  ON products(category_code) WHERE deleted_at IS NULL;
+
+ANALYZE products;
+
+-- coupons: 사용자별 상태 조회 + 만료 UPDATE 쿼리 (15% 트래픽 — GET /coupons)
+CREATE INDEX IF NOT EXISTS idx_coupons_user_status
+  ON coupons(user_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_coupons_user_status_expired
+  ON coupons(user_id, status, expired_at);
+
+ANALYZE coupons;
+
+-- orders: 사용자별 최신순 조회 (15% 트래픽 — POST /orders 후 조회)
+CREATE INDEX IF NOT EXISTS idx_orders_user_created
+  ON orders(user_id, created_at DESC);
+
+ANALYZE orders;


### PR DESCRIPTION
## Summary

시나리오 A (이벤트 오픈 스파이크, 1000 VU) Round 1 측정을 위한 SQL 인덱스 추가.

Round 0에서 `http_req_failed 69.90%`, `p95 6.04s`가 나온 주요 원인은 DB 쿼리 지연으로 인한 HikariCP 점유 시간 증가 → Tomcat 연결 큐 압박. 인덱스로 쿼리 응답시간을 단축해 커넥션 반환을 빠르게 하는 것이 목표.

| 테이블 | 추가 인덱스 | 대상 쿼리 | 트래픽 비중 |
|---|---|---|---|
| `products` | `idx_products_not_deleted` (partial) | `WHERE deleted_at IS NULL` | 40% |
| `products` | `idx_products_category_not_deleted` (partial) | `WHERE category_code=? AND deleted_at IS NULL` | 40% |
| `coupons` | `idx_coupons_user_status` | `WHERE user_id=? AND status=?` | 15% |
| `coupons` | `idx_coupons_user_status_expired` | 만료 UPDATE 쿼리 | 15% |
| `orders` | `idx_orders_user_created` | `ORDER BY created_at DESC WHERE user_id=?` | 15% |

> `cart_items`는 기존 UNIQUE 제약 `(user_id, product_id)`가 이미 인덱스로 동작하므로 제외.

## Test plan

- [ ] 백엔드 재기동 후 로그에서 `Migrating schema "public" to version 4` 확인
- [ ] `\di products` / `\di coupons` / `\di orders` 로 인덱스 생성 확인
- [ ] 환경 리셋 SQL + `redis-cli FLUSHDB`
- [ ] k6 시나리오 A 2회 실행 → 2회차 결과 `docs/시나리오 A/시나리오 A_Round1(인덱스).md` 기록
- [ ] Round 0 대비 `http_req_failed`, `p95` 개선 여부 비교