### PR TITLE
perf: 시나리오 A/D/E Round 2 — N+1 쿼리 제거 및 채팅 DB 조회 최적화

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/myfave/api/domain/chat/controller/ChatMessageController.java
@@ -7,8 +7,6 @@ import com.myfave.api.domain.chat.dto.request.ChatMessageRequest;
 import com.myfave.api.domain.chat.dto.response.ChatMessageResponse;
 import com.myfave.api.domain.chat.service.ChatMessageService;
 import com.myfave.api.domain.chat.service.RedisPublisher;
-import com.myfave.api.domain.user.entity.User;
-import com.myfave.api.domain.user.service.UserService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.validation.Valid;
@@ -29,7 +27,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-    private final UserService userService;
     private final ChatMessageService chatMessageService;
     private final RedisPublisher redisPublisher;
     private final SimpMessagingTemplate messagingTemplate;
@@ -61,7 +58,7 @@ public class ChatMessageController {
             return;
         }
 
-        User user = userService.findUserById(userId);
+        String nickname = (String) headerAccessor.getSessionAttributes().get("nickname");
 
         // XSS 방어
         String safeContent = HtmlUtils.htmlEscape(request.getPayload().getContent());
@@ -69,7 +66,7 @@ public class ChatMessageController {
         ChatMessageResponse response = ChatMessageResponse.newMessage(
                 UUID.randomUUID().toString(),
                 userId,
-                user.getNickname(),
+                nickname,
                 safeContent
         );
 

--- a/backend/src/main/java/com/myfave/api/domain/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/repository/OrderItemRepository.java
@@ -3,6 +3,8 @@ package com.myfave.api.domain.order.repository;
 import com.myfave.api.domain.order.entity.Order;
 import com.myfave.api.domain.order.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +12,7 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     // 주문에 포함된 상품 목록
     List<OrderItem> findByOrder(Order order);
+
+    @Query("SELECT oi FROM OrderItem oi WHERE oi.order IN :orders")
+    List<OrderItem> findByOrderIn(@Param("orders") List<Order> orders);
 }

--- a/backend/src/main/java/com/myfave/api/domain/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/repository/OrderItemRepository.java
@@ -13,6 +13,6 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     // 주문에 포함된 상품 목록
     List<OrderItem> findByOrder(Order order);
 
-    @Query("SELECT oi FROM OrderItem oi WHERE oi.order IN :orders")
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.order WHERE oi.order IN :orders")
     List<OrderItem> findByOrderIn(@Param("orders") List<Order> orders);
 }

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -138,8 +138,9 @@ public class OrderService {
                     .sorted(Comparator.naturalOrder())
                     .toList();
 
-            List<Product> products = productRepository.findAllById(sortedProductIds);
-            if (products.size() != sortedProductIds.size()) {
+            List<Long> distinctProductIds = sortedProductIds.stream().distinct().toList();
+            List<Product> products = productRepository.findAllById(distinctProductIds);
+            if (products.size() != distinctProductIds.size()) {
                 throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
             }
             Map<Long, Product> productMap = products.stream()

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -191,13 +191,10 @@ public class OrderService {
             return OrderListResponse.from(Page.empty(pageable));
         }
 
-        // ── 4. OrderItem 주문별 단건 조회 (의도적 N+1 발생 — 부하 실측용) ─
-        // 운영에서는 findByOrderIn(orders)로 IN 쿼리 1회 사용. 실측을 위해 단건 루프로 교체.
-        Map<Long, List<OrderItem>> itemsByOrderId = orders.stream()
-                .collect(Collectors.toMap(
-                        Order::getOrderId,
-                        order -> orderItemRepository.findByOrder(order)
-                ));
+        // ── 4. OrderItem IN 쿼리 1회 조회 (N+1 제거 — Round 2) ─────────────
+        List<OrderItem> allItems = orderItemRepository.findByOrderIn(orders);
+        Map<Long, List<OrderItem>> itemsByOrderId = allItems.stream()
+                .collect(Collectors.groupingBy(item -> item.getOrder().getOrderId()));
 
         // ── 6. 주문별 DTO 변환 ──────────────────────────────────────────
         List<OrderSummaryResponse> summaries = orders.stream()

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -196,7 +196,7 @@ public class OrderService {
         Map<Long, List<OrderItem>> itemsByOrderId = allItems.stream()
                 .collect(Collectors.groupingBy(item -> item.getOrder().getOrderId()));
 
-        // ── 6. 주문별 DTO 변환 ──────────────────────────────────────────
+        // ── 5. 주문별 DTO 변환 ──────────────────────────────────────────
         List<OrderSummaryResponse> summaries = orders.stream()
                 .map(order -> OrderSummaryResponse.from(
                         order,
@@ -205,7 +205,7 @@ public class OrderService {
                 ))
                 .toList();
 
-        // ── 7. Page<OrderSummaryResponse>로 래핑 후 반환 ────────────────
+        // ── 6. Page<OrderSummaryResponse>로 래핑 후 반환 ────────────────
         // PageImpl: content + pageable + totalElements를 조합해 Page 객체 생성
         Page<OrderSummaryResponse> summaryPage =
                 new PageImpl<>(summaries, pageable, orderPage.getTotalElements());

--- a/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/myfave/api/domain/order/service/OrderService.java
@@ -65,6 +65,7 @@ public class OrderService {
         String type = request.getOrderType() != null ? request.getOrderType().name() : "UNKNOWN";
         String outcome = "failure";
         try {
+        int itemCount = 0;
 
         // ── 1. 사용자 조회 ──────────────────────────────────────────────
         if (userId == null) {
@@ -124,6 +125,7 @@ public class OrderService {
                     .productName(product.getProductName())
                     .build();
             orderItemRepository.save(orderItem);
+            itemCount = 1;
 
         } else {
             // ── CART: 장바구니 상품 구매 ─────────────────────────────
@@ -136,10 +138,15 @@ public class OrderService {
                     .sorted(Comparator.naturalOrder())
                     .toList();
 
+            List<Product> products = productRepository.findAllById(sortedProductIds);
+            if (products.size() != sortedProductIds.size()) {
+                throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+            }
+            Map<Long, Product> productMap = products.stream()
+                    .collect(Collectors.toMap(Product::getProductId, p -> p));
             List<Product> validatedProducts = new ArrayList<>();
             for (Long pid : sortedProductIds) {
-                Product product = productRepository.findById(pid)
-                        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+                Product product = productMap.get(pid);
                 product.validateStock(1);
                 validatedProducts.add(product);
             }
@@ -153,11 +160,11 @@ public class OrderService {
                         .build();
                 orderItemRepository.save(orderItem);
             }
+            itemCount = validatedProducts.size();
         }
 
         // ── 7. 응답 반환 ───────────────────────────────────────────────
         // OrderResponse.from(order): order 엔티티에서 필요한 필드만 뽑아 DTO로 변환
-        int itemCount = orderItemRepository.findByOrder(order).size();
         log.info("[Order] 주문 생성: orderId={}, userId={}, type={}, itemCount={}",
                 order.getOrderId(), userId, type, itemCount);
         outcome = "success";

--- a/backend/src/main/java/com/myfave/api/domain/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/repository/PaymentRepository.java
@@ -4,6 +4,8 @@ import com.myfave.api.domain.order.entity.Order;
 import com.myfave.api.domain.payment.entity.Payment;
 import com.myfave.api.domain.payment.entity.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -11,6 +13,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    // Payment + Order + User를 한 번에 조회 (validateForConfirm, validateForCancel, getPayment용)
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order o JOIN FETCH o.user WHERE p.paymentId = :paymentId")
+    Optional<Payment> findByIdWithOrderAndUser(@Param("paymentId") Long paymentId);
+
+    // Payment + Order만 조회 (decreaseStockForConfirm용 — orderItems 순회를 위해 Order만 필요)
+    @Query("SELECT p FROM Payment p JOIN FETCH p.order WHERE p.paymentId = :paymentId")
+    Optional<Payment> findByIdWithOrder(@Param("paymentId") Long paymentId);
 
     // FAILED/CANCELLED를 제외한 활성 결제 조회 (중복 결제 준비 방지)
     Optional<Payment> findByOrderAndPaymentStatusNotIn(Order order, Collection<PaymentStatus> statuses);

--- a/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
@@ -262,7 +262,7 @@ public class PaymentService {
     // 결제 승인 직전 재고 확정 차감 — over-selling 방지를 위해 PESSIMISTIC_WRITE 락 사용
     @Transactional
     public void decreaseStockForConfirm(Long paymentId) {
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdWithOrder(paymentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
         List<OrderItem> orderItems = orderItemRepository.findByOrder(payment.getOrder());
@@ -303,7 +303,7 @@ public class PaymentService {
     // DB에서 유저와 결제 상태 확인
     @Transactional(readOnly = true)
     public ConfirmContext validateForConfirm(Long userId, Long paymentId) {
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdWithOrderAndUser(paymentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
         if (!payment.getOrder().getUser().getUserId().equals(userId)) {
             throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
@@ -359,7 +359,7 @@ public class PaymentService {
         if (userId == null) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
         }
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdWithOrderAndUser(paymentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.getOrder().getUser().getUserId().equals(userId)) {
@@ -412,7 +412,7 @@ public class PaymentService {
     // 결제 취소
     @Transactional(readOnly = true)
     public CancelContext validateForCancel(Long userId, Long paymentId, PaymentCancelRequest request) {
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdWithOrderAndUser(paymentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.getOrder().getUser().getUserId().equals(userId)) {

--- a/backend/src/main/java/com/myfave/api/global/config/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/myfave/api/global/config/JwtChannelInterceptor.java
@@ -1,5 +1,7 @@
 package com.myfave.api.global.config;
 
+import com.myfave.api.domain.user.entity.User;
+import com.myfave.api.domain.user.repository.UserRepository;
 import com.myfave.api.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -29,7 +32,13 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 String token = authHeader.substring(7);
                 if (jwtTokenProvider.validateToken(token)) {
                     Long userId = jwtTokenProvider.getUserId(token);
+                    User user = userRepository.findById(userId).orElse(null);
+                    if (user == null) {
+                        log.warn("STOMP CONNECT 거부: 사용자를 찾을 수 없음 userId={}", userId);
+                        return null;
+                    }
                     accessor.getSessionAttributes().put("userId", userId);
+                    accessor.getSessionAttributes().put("nickname", user.getNickname());
                 } else {
                     log.warn("STOMP CONNECT 거부: 유효하지 않은 토큰");
                     return null;


### PR DESCRIPTION
## 개요

Round 1 부하 테스트 결과를 바탕으로 N+1 쿼리 및 반복 DB 조회를 제거하여 Round 2 측정 환경을 준비한다.

- 시나리오 A: 에러율 69%, p95 6.85s → DB 커넥션 풀 고갈의 직접 원인인 N+1 제거
- 시나리오 D: PESSIMISTIC_WRITE 경로 LAZY 체인 해소 → latency 추가 감소 기대
- 시나리오 E: 채팅 메시지 발행마다 발생하던 User DB 조회 제거 → CONNECT 시 1회 세션 캐시

## 변경 사항

### 1. `OrderService.getOrders()` — N+1 핵심 제거

`getOrders()`는 주문 목록 페이지마다 OrderItem을 주문 수(N)만큼 SELECT했음.
- **Before**: `findByOrder(order)` N번 루프 (의도적 N+1, 부하 실측용으로 삽입됐던 코드)
- **After**: `findByOrderIn(orders)` IN 쿼리 1회 + `Collectors.groupingBy`
- JPQL에 `JOIN FETCH oi.order` 추가로 groupingBy 시 발생하는 2차 LAZY 체인까지 제거

### 2. `OrderService.createOrder()` CART 분기 — 상품 조회 N번 제거

장바구니 주문 생성 시 상품 수만큼 `findById` N번 호출.
- **Before**: `productRepository.findById(pid)` for 루프
- **After**: `productRepository.findAllById(sortedProductIds)` 1회 + Map 조회
- 사이즈 불일치 선행 검증으로 NPE 방지
- 응답 시 `orderItemRepository.findByOrder(order).size()` 불필요 재조회도 함께 제거

### 3. `PaymentService` LAZY 3-depth 체인 — Fetch Join 교체

`payment.getOrder().getUser().getUserId()` 패턴이 3곳에서 Payment → Order → User 3-depth LAZY를 유발.
- **Repository**: `findByIdWithOrderAndUser`, `findByIdWithOrder` 쿼리 추가
- **Service**: `validateForConfirm`, `validateForCancel`, `getPayment` → `findByIdWithOrderAndUser`
- **Service**: `decreaseStockForConfirm` → `findByIdWithOrder`

### 4. 채팅 메시지 발행마다 발생하던 User DB 조회 제거

메시지 발행 시 `userService.findUserById(userId)` → `user.getNickname()` 패턴이 메시지마다 DB를 조회.
- **Before**: 메시지 발행마다 `users` 테이블 SELECT 1회
- **After**: CONNECT 시 `userRepository.findById(userId)` 1회 → `nickname`을 세션 attributes에 캐시 → 메시지 발행 시 세션에서 꺼냄
- `JwtChannelInterceptor`: `UserRepository` 추가, CONNECT 시 nickname 세션 저장, User 없으면 CONNECT 거부
- `ChatMessageController`: `UserService` 의존 완전 제거

## 안전성 검증

- PESSIMISTIC_WRITE 락 순서 (productId ASC 정렬) 무변경
- 결제 Saga 보상 트랜잭션 흐름 무변경
- over-selling 방지 로직(`validateStock` + `decreaseStock`) 무변경
- WebSocket 인증 흐름(`userId == null` early-return) 무변경

## 변경 파일

| 파일 | 변경 내용 |
|-----|---------|
| `OrderItemRepository.java` | `findByOrderIn` 추가 (JOIN FETCH) |
| `OrderService.java` | getOrders N+1 제거, createOrder CART findAllById |
| `PaymentRepository.java` | `findByIdWithOrderAndUser`, `findByIdWithOrder` 추가 |
| `PaymentService.java` | 4곳 Fetch Join 쿼리 교체 |
| `JwtChannelInterceptor.java` | CONNECT 시 nickname 세션 캐시 |
| `ChatMessageController.java` | UserService 의존 제거, 세션에서 nickname 조회 |

## Round 2 목표 기준

| 시나리오 | 지표 | Round 1 | Round 2 목표 |
|---------|------|---------|------------|
| A | 에러율 | 69.28% | < 1% |
| A | p95 | 6.85s | < 2s |
| D | over-selling | 0건 | 0건 유지 |
| D | p95 | 2.17s | < 1.8s |
| E | chat_connect_failed | 65,165 | < 10 (SockJS 브랜치 머지 후) |
| E | chat_messages_received | 0 | > 0 |