### PR TITLE
fix: 채팅 히스토리 [공식] 메시지 위치 버그 수정

### DIFF
--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -9,7 +9,7 @@ export interface ChatHistoryMessage {
   messageId: string
   senderId: number
   senderNickname: string
-  isInfluencer: boolean
+  influencer: boolean
   content: string
   createdAt: string
 }

--- a/frontend/src/pages/LiveChatPage.tsx
+++ b/frontend/src/pages/LiveChatPage.tsx
@@ -34,9 +34,9 @@ function historyToMessage(msg: ChatHistoryMessage): Message {
     id: msg.messageId,
     user: msg.senderNickname,
     text: msg.content,
-    avatarType: msg.isInfluencer ? 'seller' : 'bear',
-    avatarVariant: msg.isInfluencer ? 1 : getVariantFromNickname(msg.senderNickname),
-    isOfficial: msg.isInfluencer,
+    avatarType: msg.influencer ? 'seller' : 'bear',
+    avatarVariant: msg.influencer ? 1 : getVariantFromNickname(msg.senderNickname),
+    isOfficial: msg.influencer,
     timestamp: new Date(msg.createdAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
   }
 }


### PR DESCRIPTION
## Summary

- `ChatHistoryMessage` 타입의 `isInfluencer` → `influencer` 필드명 수정
- Jackson은 `boolean influencer` 필드의 Lombok getter(`isInfluencer()`)를 직렬화할 때 `is` 접두사를 제거하여 JSON key를 `"influencer"`로 내려보내지만, 프론트가 `"isInfluencer"`로 읽고 있어 항상 `undefined`가 되던 문제 해결
- 결과적으로 채팅방을 나갔다가 재진입 시 히스토리로 불러온 `[공식]` 메시지가 왼쪽(일반 유저 위치)에 표시되던 버그 수정

## Test plan

- [ ] 채팅방 입장 → `[공식]의왕` 계정으로 메시지 전송 → 실시간으로 오른쪽에 표시되는지 확인
- [ ] 채팅방 나갔다가 재진입 → 히스토리 로드 후 `[공식]` 메시지가 오른쪽에 표시되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 채팅 기능의 내부 필드 명칭 및 관련 로직을 정리했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->