### PR TITLE
feat: [ProductDetailPage] isSoldOut 시 장바구니·구매 버튼 비활성화

### DIFF
--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -63,6 +63,7 @@ function toProductDetail(item: ProductDetailApiResponse): ProductDetail {
     price: item.price.toLocaleString() + '원',
     priceNumber: item.price,
     images,
+    isSoldOut: item.isSoldOut,
     features: item.description
       ? [{ title: '상품 설명', description: item.description }]
       : [],

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -22,6 +22,7 @@ export interface ProductDetail {
   priceNumber: number
   images: string[]
   features: ProductFeature[]
+  isSoldOut: boolean
 }
 
 export interface InfluencerPick extends Product {

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -215,13 +215,21 @@ export function ProductDetailPage() {
       </div>
 
       <div className="fixed bottom-0 left-1/2 z-40 flex w-full max-w-[376.04px] -translate-x-1/2 border-t border-separator bg-white shadow-figma-popup">
-        <button type="button" onClick={handleAddToCart} className="flex-1 flex h-[49.15px] items-center justify-center gap-[8px] bg-white text-[#322927] border-r border-separator active:bg-gray-50 transition-all">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" /><line x1="3" y1="6" x2="21" y2="6" /><path d="M16 10a4 4 0 0 1-8 0" /></svg>
-          <span className="font-noto text-[14px] font-bold">장바구니</span>
-        </button>
-        <button type="button" onClick={handleBuyNow} className="flex-1 flex h-[49.15px] items-center justify-center bg-point text-white active:bg-[#ff7fa3] transition-all">
-          <span className="font-noto text-[14px] font-bold">구매하기</span>
-        </button>
+        {product.isSoldOut ? (
+          <div className="flex-1 flex h-[49.15px] items-center justify-center bg-separator">
+            <span className="font-noto text-[14px] font-bold text-muted-text">품절</span>
+          </div>
+        ) : (
+          <>
+            <button type="button" onClick={handleAddToCart} className="flex-1 flex h-[49.15px] items-center justify-center gap-[8px] bg-white text-[#322927] border-r border-separator active:bg-gray-50 transition-all">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" /><line x1="3" y1="6" x2="21" y2="6" /><path d="M16 10a4 4 0 0 1-8 0" /></svg>
+              <span className="font-noto text-[14px] font-bold">장바구니</span>
+            </button>
+            <button type="button" onClick={handleBuyNow} className="flex-1 flex h-[49.15px] items-center justify-center bg-point text-white active:bg-[#ff7fa3] transition-all">
+              <span className="font-noto text-[14px] font-bold">구매하기</span>
+            </button>
+          </>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- `ProductDetail` 타입에 `isSoldOut: boolean` 필드 추가
- `toProductDetail()` 에서 백엔드 `isSoldOut` 값 매핑
- 상품 상세 페이지에서 `isSoldOut: true` 인 경우 장바구니·구매하기 버튼을 회색 **품절** 바로 교체

## 변경 파일

| 파일 | 내용 |
|------|------|
| `features/products/types.ts` | `ProductDetail`에 `isSoldOut: boolean` 추가 |
| `features/products/hooks.ts` | `toProductDetail`에서 `isSoldOut` 매핑 |
| `pages/ProductDetailPage.tsx` | `isSoldOut` 조건부 버튼 비활성화 처리 |

## Test plan

- [ ] `isSoldOut: true` 상품 상세 진입 → 하단 바가 회색 "품절" 텍스트로 표시 확인
- [ ] `isSoldOut: false` 상품 상세 진입 → 장바구니·구매하기 버튼 정상 표시 확인