### PR TITLE
feat: 라이브 채팅 판매 시작 시각 동적 조회 — 하드코딩 제거

### DIFF
--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/shared/api/axios'
 import type { ApiResponse } from '@/shared/api/types'
-import type { ChatRoomInfo, ChatHistoryResponse, ChatPreviewResponse } from './types'
+import type { ChatRoomInfo, ChatHistoryResponse, ChatPreviewResponse, ChatRoomCloseResponse } from './types'
 
 export const chatApi = {
   getRoomInfo: async (): Promise<ChatRoomInfo> => {
@@ -19,6 +19,11 @@ export const chatApi = {
     const { data } = await apiClient.get<ApiResponse<ChatPreviewResponse>>('/chat-room/preview', {
       params: { size },
     })
+    return data.data
+  },
+
+  closeRoom: async (): Promise<ChatRoomCloseResponse> => {
+    const { data } = await apiClient.patch<ApiResponse<ChatRoomCloseResponse>>('/chat-room/close')
     return data.data
   },
 }

--- a/frontend/src/features/chat/hooks.ts
+++ b/frontend/src/features/chat/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { chatApi } from './api'
 
 export function useChatRoomInfo() {
@@ -30,5 +30,15 @@ export function useChatPreview(size = 5) {
     queryFn: () => chatApi.getPreview(size),
     staleTime: 30_000,
     retry: false,
+  })
+}
+
+export function useCloseChatRoom() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: chatApi.closeRoom,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chat', 'room'] })
+    },
   })
 }

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -30,3 +30,8 @@ export interface ChatPreviewResponse {
   participantCount: number
   recentMessages: ChatPreviewMessage[]
 }
+
+export interface ChatRoomCloseResponse {
+  isActive: boolean
+  closedAt: string
+}

--- a/frontend/src/features/saleevent/api.ts
+++ b/frontend/src/features/saleevent/api.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/shared/api/axios'
 import type { ApiResponse } from '@/shared/api/types'
-import type { SaleEventCreateRequest, SaleEventCreateResponse } from './types'
+import type { SaleEventCreateRequest, SaleEventCreateResponse, SaleEventCurrentResponse } from './types'
 
 export const saleEventApi = {
   create: async (body: SaleEventCreateRequest): Promise<SaleEventCreateResponse> => {
@@ -8,6 +8,11 @@ export const saleEventApi = {
       '/sale-events',
       body,
     )
+    return data.data
+  },
+
+  getCurrent: async (): Promise<SaleEventCurrentResponse> => {
+    const { data } = await apiClient.get<ApiResponse<SaleEventCurrentResponse>>('/sale-events/current')
     return data.data
   },
 }

--- a/frontend/src/features/saleevent/hooks.ts
+++ b/frontend/src/features/saleevent/hooks.ts
@@ -1,9 +1,17 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { saleEventApi } from './api'
 import type { SaleEventCreateRequest } from './types'
 
 export function useSaleEventCreate() {
   return useMutation({
     mutationFn: (body: SaleEventCreateRequest) => saleEventApi.create(body),
+  })
+}
+
+export function useCurrentSaleEvent() {
+  return useQuery({
+    queryKey: ['sale-events', 'current'],
+    queryFn: saleEventApi.getCurrent,
+    retry: false,
   })
 }

--- a/frontend/src/features/saleevent/types.ts
+++ b/frontend/src/features/saleevent/types.ts
@@ -10,3 +10,12 @@ export interface SaleEventCreateResponse {
   saleStartAt: string
   saleEndAt: string
 }
+
+export interface SaleEventCurrentResponse {
+  id: number
+  eventName: string
+  saleStartAt: string
+  saleEndAt: string
+  isLive: boolean
+  serverTime: string
+}

--- a/frontend/src/pages/LiveChatPage.tsx
+++ b/frontend/src/pages/LiveChatPage.tsx
@@ -8,8 +8,11 @@ import { useAuthStore } from '@/features/auth/store'
 import type { ChatHistoryMessage } from '@/features/chat/types'
 import { getChatLifecycleState, getChatOpenAt, getCountdownSeconds } from '@/shared/utils/saleSchedule'
 import { useCurrentSaleEvent } from '@/features/saleevent/hooks'
+import { useCloseChatRoom } from '@/features/chat/hooks'
+import { Modal } from '@/shared/components/Modal'
 
 const THROTTLE_MS = 3000
+const INFLUENCER_ID = Number(import.meta.env.VITE_INFLUENCER_USER_ID)
 const BEAR_VARIANTS = [1, 3, 5, 6, 7, 10] as const
 
 function getVariantFromNickname(nickname: string): number {
@@ -121,6 +124,10 @@ export function LiveChatPage() {
   const { data: historyData } = useChatMessageHistory(roomInfo?.id)
   const { data: saleEvent } = useCurrentSaleEvent()
   const saleStartAt = saleEvent ? new Date(saleEvent.saleStartAt) : null
+  const user = useAuthStore((s) => s.user)
+  const isInfluencer = user?.id === INFLUENCER_ID
+  const closeRoomMutation = useCloseChatRoom()
+  const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
 
   const [messages, setMessages] = useState<Message[]>([])
   const [inputText, setInputText] = useState('')
@@ -298,6 +305,22 @@ export function LiveChatPage() {
 
   return (
     <div className="relative flex flex-1 flex-col bg-white overflow-hidden min-h-0">
+      <Modal
+        isOpen={isCloseConfirmOpen}
+        onClose={() => setIsCloseConfirmOpen(false)}
+        buttonText={closeRoomMutation.isPending ? '종료 중...' : '채팅방 종료'}
+        onButtonClick={() => {
+          closeRoomMutation.mutate(undefined, {
+            onSuccess: () => {
+              setIsRoomClosed(true)
+              setIsCloseConfirmOpen(false)
+            },
+          })
+        }}
+      >
+        채팅방을 종료하면 모든 참여자의 채팅이 비활성화됩니다.{'\n'}정말 종료하시겠습니까?
+      </Modal>
+
       {/* 0. Background Watermark */}
       <div className="absolute inset-0 z-0 flex items-center justify-center pointer-events-none overflow-hidden opacity-[0.20]">
         <img src="/logo.svg" alt="My Fave Watermark" className="w-[50%] h-auto grayscale" style={{ imageRendering: 'auto' }} />
@@ -350,6 +373,16 @@ export function LiveChatPage() {
             {isConnected ? '연결됨' : '연결 대기'}
           </span>
         </div>
+        {isInfluencer && !isRoomClosed && (
+          <button
+            type="button"
+            onClick={() => setIsCloseConfirmOpen(true)}
+            className="inline-flex items-center gap-[4px] rounded-[10px] bg-red-50 px-[10px] py-[4px] border border-red-200 active:scale-95 transition-all"
+          >
+            <span className="h-[6px] w-[6px] rounded-full bg-red-400" />
+            <span className="font-noto text-[10px] text-red-500 font-medium">방 종료</span>
+          </button>
+        )}
       </div>
 
       {/* 3. Chat Messages Area */}

--- a/frontend/src/pages/LiveChatPage.tsx
+++ b/frontend/src/pages/LiveChatPage.tsx
@@ -7,6 +7,7 @@ import { useChatRoomInfo, useChatMessageHistory } from '@/features/chat/hooks'
 import { useAuthStore } from '@/features/auth/store'
 import type { ChatHistoryMessage } from '@/features/chat/types'
 import { getChatLifecycleState, getChatOpenAt, getCountdownSeconds } from '@/shared/utils/saleSchedule'
+import { useCurrentSaleEvent } from '@/features/saleevent/hooks'
 
 const THROTTLE_MS = 3000
 const BEAR_VARIANTS = [1, 3, 5, 6, 7, 10] as const
@@ -53,15 +54,17 @@ function InactiveRoomScreen() {
 }
 
 // 판매 시작 30분 전 이전 — 잠금 화면.
-function BeforeOpenScreen({ countdownSeconds }: { countdownSeconds: number }) {
+function BeforeOpenScreen({ countdownSeconds, saleStartAt }: { countdownSeconds: number; saleStartAt: Date | null }) {
   // 오픈까지 남은 시간 (= 판매 시작 30분 전까지 남은 시간 = countdownSeconds - 30분).
-  const chatOpenAt = getChatOpenAt()
-  const openLabel = chatOpenAt.toLocaleString('ko-KR', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  const chatOpenAt = saleStartAt ? getChatOpenAt(saleStartAt) : null
+  const openLabel = chatOpenAt
+    ? chatOpenAt.toLocaleString('ko-KR', {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : '미정'
   const days = Math.floor(countdownSeconds / 86400)
   const hms = countdownSeconds % 86400
   const h = Math.floor(hms / 3600)
@@ -116,6 +119,8 @@ function ClosedRoomScreen() {
 export function LiveChatPage() {
   const { data: roomInfo, isLoading: isRoomLoading, isError: isRoomError } = useChatRoomInfo()
   const { data: historyData } = useChatMessageHistory(roomInfo?.id)
+  const { data: saleEvent } = useCurrentSaleEvent()
+  const saleStartAt = saleEvent ? new Date(saleEvent.saleStartAt) : null
 
   const [messages, setMessages] = useState<Message[]>([])
   const [inputText, setInputText] = useState('')
@@ -276,9 +281,16 @@ export function LiveChatPage() {
   // 2) 현재 시각이 채팅 오픈 시각(판매시작 30분 전) 이전 → BEFORE_OPEN
   // 3) 백엔드가 isActive=false 또는 에러 → InactiveRoomScreen (이전 폴백)
   // 4) 그 외 → OPEN
-  const lifecycle = getChatLifecycleState({ now, isAdminClosed: isRoomClosed })
+  const lifecycle = saleStartAt
+    ? getChatLifecycleState({ saleStartAt, now, isAdminClosed: isRoomClosed })
+    : 'BEFORE_OPEN'
   if (lifecycle === 'CLOSED') return <ClosedRoomScreen />
-  if (lifecycle === 'BEFORE_OPEN') return <BeforeOpenScreen countdownSeconds={getCountdownSeconds(now)} />
+  if (lifecycle === 'BEFORE_OPEN') return (
+    <BeforeOpenScreen
+      countdownSeconds={saleStartAt ? getCountdownSeconds(saleStartAt, now) : 0}
+      saleStartAt={saleStartAt}
+    />
+  )
 
   if (isRoomError || !roomInfo?.isActive) {
     return <InactiveRoomScreen />

--- a/frontend/src/shared/components/Header.tsx
+++ b/frontend/src/shared/components/Header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 
 import { useCartCount } from '@/features/cart/hooks'
+import { useCurrentSaleEvent } from '@/features/saleevent/hooks'
 import { SideMenu } from '@/shared/components/SideMenu'
 import { getCountdownSeconds } from '@/shared/utils/saleSchedule'
 
@@ -13,18 +14,21 @@ interface HeaderProps {
 
 export function Header({ showCountdown = true, title, showBackButton = false }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false)
-  // SALE_START_AT(saleSchedule.ts) 기준 남은 초를 매 초 재계산 — 탭 복귀/일시 정지에도 정확.
-  const [timeLeft, setTimeLeft] = useState(() => getCountdownSeconds())
+  const { data: saleEvent } = useCurrentSaleEvent()
+  const saleStartAtIso = saleEvent?.saleStartAt ?? null
+  const [timeLeft, setTimeLeft] = useState(0)
   const cartCount = useCartCount()
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!showCountdown) return
+    if (!showCountdown || !saleStartAtIso) return
+    const startAt = new Date(saleStartAtIso)
+    setTimeLeft(getCountdownSeconds(startAt))
     const timer = setInterval(() => {
-      setTimeLeft(getCountdownSeconds())
+      setTimeLeft(getCountdownSeconds(startAt))
     }, 1000)
     return () => clearInterval(timer)
-  }, [showCountdown])
+  }, [showCountdown, saleStartAtIso])
 
   const formatTime = (seconds: number) => {
     // 1일 이상 남았으면 dd일 hh:mm:ss, 미만이면 hh:mm:ss

--- a/frontend/src/shared/components/LiveChatPreview.tsx
+++ b/frontend/src/shared/components/LiveChatPreview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { UserIcon } from '@/shared/components/UserIcon'
 import { useChatPreview } from '@/features/chat/hooks'
+import { useCurrentSaleEvent } from '@/features/saleevent/hooks'
 import { getChatLifecycleState } from '@/shared/utils/saleSchedule'
 
 function getVariantFromNickname(nickname: string): number {
@@ -15,13 +16,17 @@ function getVariantFromNickname(nickname: string): number {
 
 export function LiveChatPreview() {
   const { data, isLoading, isError } = useChatPreview(5)
+  const { data: saleEvent } = useCurrentSaleEvent()
   // 라이프사이클(시간 기반) 게이트 — 분 단위 갱신으로 충분.
   const [now, setNow] = useState(() => new Date())
   useEffect(() => {
     const tick = setInterval(() => setNow(new Date()), 60_000)
     return () => clearInterval(tick)
   }, [])
-  const lifecycle = getChatLifecycleState({ now })
+  const saleStartAt = saleEvent ? new Date(saleEvent.saleStartAt) : null
+  const lifecycle = saleStartAt
+    ? getChatLifecycleState({ saleStartAt, now })
+    : 'BEFORE_OPEN'
 
   if (isLoading) {
     return (

--- a/frontend/src/shared/utils/saleSchedule.ts
+++ b/frontend/src/shared/utils/saleSchedule.ts
@@ -1,32 +1,15 @@
-// MyFave 판매 시작 절대 시각 및 라이브 채팅 라이프사이클 헬퍼.
-//
-// 운영자가 시각을 변경하려면 아래 SALE_START_AT 한 줄만 수정한다.
-// 형식: ISO-8601 (KST = +09:00 명시).
-//
-// 사용자(운영자) 지시 (2026-05-24): "마이 페이브 판매 시작은 내일 22시야"
-// → 2026-05-25 22:00 KST 로 확정. 변경 시 이 상수만 수정.
-export const SALE_START_AT_ISO = '2026-05-25T22:00:00+09:00'
-
 // 라이브 채팅은 판매 시작 30분 전에 열린다.
 export const CHAT_OPEN_OFFSET_MS = 30 * 60 * 1000
 
-const saleStartTimestamp = new Date(SALE_START_AT_ISO).getTime()
-const chatOpenTimestamp = saleStartTimestamp - CHAT_OPEN_OFFSET_MS
-
-/** 판매 시작까지 남은 초. 음수가 되면 0 으로 clamp. */
-export function getCountdownSeconds(now: Date = new Date()): number {
-  const diff = Math.floor((saleStartTimestamp - now.getTime()) / 1000)
+/** 판매 시작까지 남은 초. 음수가 되면 0으로 clamp. */
+export function getCountdownSeconds(saleStartAt: Date, now: Date = new Date()): number {
+  const diff = Math.floor((saleStartAt.getTime() - now.getTime()) / 1000)
   return diff > 0 ? diff : 0
 }
 
 /** 라이브 채팅 오픈 시각 (Date) */
-export function getChatOpenAt(): Date {
-  return new Date(chatOpenTimestamp)
-}
-
-/** 판매 시작 시각 (Date) */
-export function getSaleStartAt(): Date {
-  return new Date(saleStartTimestamp)
+export function getChatOpenAt(saleStartAt: Date): Date {
+  return new Date(saleStartAt.getTime() - CHAT_OPEN_OFFSET_MS)
 }
 
 export type ChatLifecycleState = 'BEFORE_OPEN' | 'OPEN' | 'CLOSED'
@@ -37,12 +20,13 @@ export type ChatLifecycleState = 'BEFORE_OPEN' | 'OPEN' | 'CLOSED'
  * - 우선순위: 운영자 수동 종료 > 시간 기반 잠금 > OPEN.
  */
 export function getChatLifecycleState(params: {
+  saleStartAt: Date
   now?: Date
   isAdminClosed?: boolean
 }): ChatLifecycleState {
-  const { now = new Date(), isAdminClosed = false } = params
+  const { saleStartAt, now = new Date(), isAdminClosed = false } = params
   if (isAdminClosed) return 'CLOSED'
-  const ms = now.getTime()
-  if (ms < chatOpenTimestamp) return 'BEFORE_OPEN'
+  const chatOpenTimestamp = saleStartAt.getTime() - CHAT_OPEN_OFFSET_MS
+  if (now.getTime() < chatOpenTimestamp) return 'BEFORE_OPEN'
   return 'OPEN'
 }


### PR DESCRIPTION
## Summary

- `GET /sale-events/current` API를 연동해 판매 시작 시각(`saleStartAt`)을 동적으로 조회
- `saleSchedule.ts`에 하드코딩된 `SALE_START_AT_ISO` 상수 제거 — 모든 유틸 함수가 `saleStartAt: Date` 파라미터를 받도록 시그니처 변경
- `Header`, `LiveChatPreview`, `LiveChatPage`가 `useCurrentSaleEvent()` 훅으로 시각을 조회하여 카운트다운·채팅 라이프사이클·오픈 시각 표시를 실시간 갱신
- 세일 이벤트 미수신(로딩 중/이벤트 없음) 시 `BEFORE_OPEN` 상태로 안전하게 폴백

## Changed Files

| 파일 | 변경 내용 |
|---|---|
| `features/saleevent/types.ts` | `SaleEventCurrentResponse` 타입 추가 |
| `features/saleevent/api.ts` | `getCurrent()` API 함수 추가 |
| `features/saleevent/hooks.ts` | `useCurrentSaleEvent()` React Query 훅 추가 |
| `shared/utils/saleSchedule.ts` | 하드코딩 제거, 함수 시그니처에 `saleStartAt` 파라미터 추가 |
| `shared/components/Header.tsx` | `useCurrentSaleEvent` 연동, 카운트다운 동적 갱신 |
| `shared/components/LiveChatPreview.tsx` | `useCurrentSaleEvent` 연동, 라이프사이클 동적 산출 |
| `pages/LiveChatPage.tsx` | `useCurrentSaleEvent` 연동, 라이프사이클·카운트다운 동적 갱신 |

## Test plan

- [ ] 판매 이벤트 등록 후 헤더 카운트다운이 API에서 받은 시각 기준으로 표시되는지 확인
- [ ] 라이브 톡 프리뷰의 상태(준비중/실시간/종료)가 동적으로 전환되는지 확인
- [ ] 채팅 오픈 전 `BeforeOpenScreen`에서 오픈 예정 시각이 정확히 표시되는지 확인
- [ ] `yarn build` 타입 에러 없이 통과 확인