### PR TITLE
192 refactor 포트원 모바일 결제 오류 해결

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/payment/dto/request/PaymentPrepareRequest.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/dto/request/PaymentPrepareRequest.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public class PaymentPrepareRequest {
 
+    public enum DeviceType { PC, MOBILE }
+
     @NotNull
     private Long orderId;
 
@@ -16,4 +18,7 @@ public class PaymentPrepareRequest {
     private Long discountCouponId;   // null = 할인 쿠폰 미사용
 
     private Long shippingCouponId;   // null = 배송비 쿠폰 미사용
+
+    // null = PC 폴백 (기존 클라이언트 호환)
+    private DeviceType deviceType;
 }

--- a/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/payment/service/PaymentService.java
@@ -13,6 +13,7 @@ import com.myfave.api.domain.order.repository.OrderRepository;
 import com.myfave.api.domain.payment.dto.request.PaymentCancelRequest;
 import com.myfave.api.domain.payment.dto.request.PaymentConfirmRequest;
 import com.myfave.api.domain.payment.dto.request.PaymentPrepareRequest;
+import com.myfave.api.domain.payment.dto.request.PaymentPrepareRequest.DeviceType;
 import com.myfave.api.domain.payment.dto.request.PaymentWebhookRequest;
 import com.myfave.api.domain.payment.dto.response.PaymentPrepareResponse;
 import com.myfave.api.domain.payment.dto.response.PaymentResponse;
@@ -90,15 +91,29 @@ public class PaymentService {
     @Value("${portone.channel-key.toss-pay}")
     private String tossPayChannelKey;
 
+    @Value("${portone.channel-key.mobile-card}")
+    private String mobileCardChannelKey;
+
+    @Value("${portone.channel-key.mobile-kakao-pay}")
+    private String mobileKakaoPayChannelKey;
+
+    @Value("${portone.channel-key.mobile-naver-pay}")
+    private String mobileNaverPayChannelKey;
+
+    @Value("${portone.channel-key.mobile-toss-pay}")
+    private String mobileTossPayChannelKey;
+
     @Value("${portone.api-secret}")
     private String apiSecret;
 
-    private String resolveChannelKey(PaymentMethod method) {
+    private String resolveChannelKey(PaymentMethod method, DeviceType deviceType) {
+        // deviceType null = PC 폴백 (기존 클라이언트 호환)
+        boolean isMobile = deviceType == DeviceType.MOBILE;
         return switch (method) {
-            case CARD -> cardChannelKey;
-            case KAKAO_PAY -> kakaoPayChannelKey;
-            case NAVER_PAY -> naverPayChannelKey;
-            case TOSS_PAY -> tossPayChannelKey;
+            case CARD -> isMobile ? mobileCardChannelKey : cardChannelKey;
+            case KAKAO_PAY -> isMobile ? mobileKakaoPayChannelKey : kakaoPayChannelKey;
+            case NAVER_PAY -> isMobile ? mobileNaverPayChannelKey : naverPayChannelKey;
+            case TOSS_PAY -> isMobile ? mobileTossPayChannelKey : tossPayChannelKey;
         };
     }
 
@@ -176,7 +191,7 @@ public class PaymentService {
             throw new CustomException(ErrorCode.PAYMENT_LOCK_CONFLICT);
         }
 
-        return PaymentPrepareResponse.of(payment, storeId, resolveChannelKey(request.getPaymentMethod()));
+        return PaymentPrepareResponse.of(payment, storeId, resolveChannelKey(request.getPaymentMethod(), request.getDeviceType()));
     }
 
     public record ConfirmContext(Long paymentId, int totalPaymentPrice) {}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -73,6 +73,10 @@ portone:
     kakao-pay: ${PORTONE_CHANNEL_KEY_KAKAOPAY:local-kakao-key}
     naver-pay: ${PORTONE_CHANNEL_KEY_NAVERPAY:local-naver-key}
     toss-pay: ${PORTONE_CHANNEL_KEY_TOSSPAY:local-toss-key}
+    mobile-card: ${MOBILE_PORTONE_CHANNEL_KEY_CARD:local-mobile-card-key}
+    mobile-kakao-pay: ${MOBILE_PORTONE_CHANNEL_KEY_KAKAOPAY:local-mobile-kakao-key}
+    mobile-naver-pay: ${MOBILE_PORTONE_CHANNEL_KEY_NAVERPAY:local-mobile-naver-key}
+    mobile-toss-pay: ${MOBILE_PORTONE_CHANNEL_KEY_TOSSPAY:local-mobile-toss-key}
 
 tracker:
   client-id: ${TRACKER_CLIENT_ID:local-client-id}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -31,3 +31,11 @@ logging:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://www.myfave.shop,https://myfave.shop}
+
+# 포트원 모바일 결제 채널 (PC 키는 application.yml 에서 상속, 모바일 키만 prod 환경변수로 주입)
+portone:
+  channel-key:
+    mobile-card: ${MOBILE_PORTONE_CHANNEL_KEY_CARD}
+    mobile-kakao-pay: ${MOBILE_PORTONE_CHANNEL_KEY_KAKAOPAY}
+    mobile-naver-pay: ${MOBILE_PORTONE_CHANNEL_KEY_NAVERPAY}
+    mobile-toss-pay: ${MOBILE_PORTONE_CHANNEL_KEY_TOSSPAY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -50,6 +50,10 @@ portone:
     kakao-pay: ${PORTONE_CHANNEL_KEY_KAKAOPAY}
     naver-pay: ${PORTONE_CHANNEL_KEY_NAVERPAY}
     toss-pay: ${PORTONE_CHANNEL_KEY_TOSSPAY}
+    mobile-card: ${MOBILE_PORTONE_CHANNEL_KEY_CARD}
+    mobile-kakao-pay: ${MOBILE_PORTONE_CHANNEL_KEY_KAKAOPAY}
+    mobile-naver-pay: ${MOBILE_PORTONE_CHANNEL_KEY_NAVERPAY}
+    mobile-toss-pay: ${MOBILE_PORTONE_CHANNEL_KEY_TOSSPAY}
 
 # Delivery Tracker API (tracker.delivery)
 tracker:

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -22,6 +22,7 @@ import { TermsPage } from '@/pages/TermsPage'
 import { OrderDetailPage } from '@/pages/OrderDetailPage'
 import { OrderSuccessPage } from '@/pages/OrderSuccessPage'
 import { OrdersPage } from '@/pages/OrdersPage'
+import { PaymentCallbackPage } from '@/pages/PaymentCallbackPage'
 import { PaymentPage } from '@/pages/PaymentPage'
 import { ProductDetailPage } from '@/pages/ProductDetailPage'
 import { ProductListPage } from '@/pages/ProductListPage'
@@ -67,6 +68,7 @@ const router = createBrowserRouter([
             element: <ProtectedRoute />,
             children: [
               { path: '/payment', element: <PaymentPage /> },
+              { path: '/payment/callback', element: <PaymentCallbackPage /> },
               { path: '/shipping-addresses', element: <ShippingAddressPage /> },
               { path: '/add-shipping', element: <AddShippingPage /> },
               { path: '/coupons', element: <CouponPage /> },

--- a/frontend/src/features/payments/types.ts
+++ b/frontend/src/features/payments/types.ts
@@ -14,6 +14,9 @@ export interface CheckoutSession {
 
 export type BackendPaymentMethod = 'CARD' | 'KAKAO_PAY' | 'NAVER_PAY' | 'TOSS_PAY'
 
+// 백엔드 PaymentPrepareRequest.DeviceType 과 1:1 매핑. 생략(null) = PC 폴백.
+export type DeviceType = 'PC' | 'MOBILE'
+
 export const PAYMENT_METHOD_MAP: Record<string, BackendPaymentMethod> = {
   '카드': 'CARD',
   '카카오페이': 'KAKAO_PAY',
@@ -26,6 +29,7 @@ export interface PaymentPrepareRequest {
   paymentMethod: BackendPaymentMethod
   discountCouponId?: number
   shippingCouponId?: number
+  deviceType?: DeviceType
 }
 
 export interface PaymentPrepareResponse {

--- a/frontend/src/features/products/imageMap.ts
+++ b/frontend/src/features/products/imageMap.ts
@@ -66,7 +66,7 @@ export const imageMap: Partial<Record<number, ImageMapEntry>> = {
   11: {
     slug: 'top7',
     jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top7_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',
+    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top7_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
   },
   12: {
     slug: 'top8',

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -113,11 +113,6 @@ export function LoginPage() {
             카카오로 시작하기
           </button>
 
-          {/* Demo Account Info - added for demonstration */}
-          <p className="text-center font-noto text-[12px] text-muted-text/80">
-            시연 계정: test@test.com / password
-          </p>
-
           {/* Options & Links */}
           <div className="space-y-[15px] pt-[2px]">
             {/* Auto Login - Figma Node 148:180 */}

--- a/frontend/src/pages/PaymentCallbackPage.tsx
+++ b/frontend/src/pages/PaymentCallbackPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { paymentsApi } from '@/features/payments/api'
+import { useConfirmPayment } from '@/features/payments/hooks'
+
+import { PopUp } from '@/shared/components/PopUp'
+
+// PaymentPage.tsx 의 PENDING_PAYMENT_STORAGE_KEY 와 반드시 동일해야 한다.
+const PENDING_PAYMENT_STORAGE_KEY = 'myfave:pendingPayment'
+
+interface PendingPayment {
+  paymentId: number
+  idempotencyKey: string
+}
+
+function readPendingPayment(): PendingPayment | null {
+  try {
+    const raw = sessionStorage.getItem(PENDING_PAYMENT_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as PendingPayment
+    return typeof parsed?.paymentId === 'number' && typeof parsed?.idempotencyKey === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export function PaymentCallbackPage() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const confirmPayment = useConfirmPayment()
+  const [popUpMessage, setPopUpMessage] = useState('')
+  const [isPopUpOpen, setIsPopUpOpen] = useState(false)
+  // React StrictMode 의 effect 이중실행으로 confirm 이 2번 호출되는 것을 방지한다.
+  const hasProcessed = useRef(false)
+
+  useEffect(() => {
+    if (hasProcessed.current) return
+    hasProcessed.current = true
+
+    const code = searchParams.get('code')
+    const message = searchParams.get('message') ?? ''
+    const pgTransactionId =
+      searchParams.get('txId') ?? searchParams.get('transactionId') ?? searchParams.get('paymentId') ?? ''
+
+    const pending = readPendingPayment()
+    // sessionStorage 는 한 번 읽고 즉시 정리 — 새로고침/뒤로가기 재실행 방지.
+    sessionStorage.removeItem(PENDING_PAYMENT_STORAGE_KEY)
+
+    const openFailurePopUp = (msg: string) => {
+      setPopUpMessage(msg)
+      setIsPopUpOpen(true)
+    }
+
+    // 1) PortOne 가 실패/취소로 redirect 한 경우.
+    if (code) {
+      const isUserCancel = message.includes('취소') || message.toLowerCase().includes('cancel')
+      // 백엔드에 남은 PENDING 결제 silent cleanup — 실패해도 사용자 흐름에 영향 없음.
+      if (pending) {
+        paymentsApi
+          .cancel(pending.paymentId, { reason: isUserCancel ? 'USER_CANCEL' : `SDK_ERROR: ${message}` })
+          .catch(() => {})
+      }
+      openFailurePopUp(isUserCancel ? '결제를 취소하셨습니다.' : `결제 실패: ${message || '알 수 없는 오류'}`)
+      return
+    }
+
+    // 2) sessionStorage 가 비어있음 — 새 탭/세션 만료 등 비정상 진입.
+    if (!pending) {
+      openFailurePopUp('결제 정보를 확인할 수 없습니다. 결제 페이지에서 다시 시도해주세요.')
+      return
+    }
+
+    // 3) 정상 redirect — 백엔드 confirm 호출.
+    confirmPayment.mutate(
+      { paymentId: pending.paymentId, pgTransactionId: pgTransactionId || pending.idempotencyKey },
+      {
+        onSuccess: () => {
+          navigate('/orders', { replace: true })
+        },
+        onError: (err) => {
+          const errorCode = (err as { response?: { data?: { errorCode?: string } } })?.response?.data?.errorCode
+          const friendly =
+            errorCode === 'PAYMENT_AMOUNT_MISMATCH'
+              ? '결제 금액이 일치하지 않아 자동 환불 처리되었습니다.'
+              : errorCode === 'PAYMENT_ALREADY_DONE'
+              ? '이미 처리된 결제입니다.'
+              : '결제 승인에 실패했습니다. 잠시 후 다시 시도해주세요.'
+          openFailurePopUp(friendly)
+        },
+      },
+    )
+  }, [confirmPayment, navigate, searchParams])
+
+  const handleClosePopUp = () => {
+    setIsPopUpOpen(false)
+    navigate('/payment', { replace: true })
+  }
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-white min-h-[60vh] px-[19.99px]">
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-[#F2EDEB] border-t-[#CF879B]" />
+        <p className="font-noto text-[14px] text-[#322927]">결제 결과를 확인하고 있습니다…</p>
+      </div>
+      <PopUp isOpen={isPopUpOpen} message={popUpMessage} onClose={handleClosePopUp} />
+    </div>
+  )
+}

--- a/frontend/src/pages/PaymentPage.tsx
+++ b/frontend/src/pages/PaymentPage.tsx
@@ -27,6 +27,9 @@ interface PortOnePaymentRequest {
 // 카톡/인스타/페이스북/라인/네이버 인앱 브라우저 — PortOne 결제는 외부 앱 스킴 호출에 의존하므로 인앱 환경에서 차단됨.
 const IN_APP_BROWSER_REGEX = /KAKAOTALK|Instagram|FBAN|FBAV|Line|NAVER\(inapp/i
 
+// 백엔드 PortOne 모바일 channelKey 분기용. userAgent 기반 — 화면 너비(useIsMobile) 가 아니라 실제 디바이스로 판단해야 PG 채널이 정확히 선택된다.
+const MOBILE_DEVICE_REGEX = /iPhone|iPad|iPod|Android/i
+
 // 모바일 redirect 흐름에서 백엔드 paymentId 가 React state 로 보존되지 않으므로 sessionStorage 로 PaymentCallbackPage 까지 운반한다.
 const PENDING_PAYMENT_STORAGE_KEY = 'myfave:pendingPayment'
 
@@ -199,10 +202,11 @@ export function PaymentPage() {
           : { orderType: 'DIRECT', productId: checkoutItems[0].id, shippingAddressId: resolvedShippingId }
       const order = await createOrder.mutateAsync(orderPayload)
 
-      // 2. 결제 준비
+      // 2. 결제 준비 — deviceType 으로 PC/모바일 channelKey 분기 (백엔드 PaymentService.resolveChannelKey).
       const prepareRes = await preparePayment.mutateAsync({
         orderId: order.orderId,
         paymentMethod: backendMethod,
+        deviceType: MOBILE_DEVICE_REGEX.test(navigator.userAgent) ? 'MOBILE' : 'PC',
         ...(appliedCoupon?.couponId && appliedCoupon.couponType === 'DISCOUNT' && { discountCouponId: appliedCoupon.couponId }),
         ...(appliedCoupon?.couponId && appliedCoupon.couponType === 'SHIPPING' && { shippingCouponId: appliedCoupon.couponId }),
       })

--- a/frontend/src/pages/PaymentPage.tsx
+++ b/frontend/src/pages/PaymentPage.tsx
@@ -27,6 +27,9 @@ interface PortOnePaymentRequest {
 // 카톡/인스타/페이스북/라인/네이버 인앱 브라우저 — PortOne 결제는 외부 앱 스킴 호출에 의존하므로 인앱 환경에서 차단됨.
 const IN_APP_BROWSER_REGEX = /KAKAOTALK|Instagram|FBAN|FBAV|Line|NAVER\(inapp/i
 
+// 모바일 redirect 흐름에서 백엔드 paymentId 가 React state 로 보존되지 않으므로 sessionStorage 로 PaymentCallbackPage 까지 운반한다.
+const PENDING_PAYMENT_STORAGE_KEY = 'myfave:pendingPayment'
+
 import { useUser } from '@/features/auth/hooks'
 import { useCart } from '@/features/cart/hooks'
 import { useCartStore } from '@/features/cart/store'
@@ -207,6 +210,12 @@ export function PaymentPage() {
       // PortOne 실패/취소 시 cleanup 대상으로 저장.
       pendingPaymentId = prepareRes.paymentId
 
+      // 모바일 결제는 redirect 로 페이지가 떠나기 때문에 paymentId 를 sessionStorage 에 보존해 PaymentCallbackPage 가 confirm 호출에 사용한다.
+      sessionStorage.setItem(
+        PENDING_PAYMENT_STORAGE_KEY,
+        JSON.stringify({ paymentId: prepareRes.paymentId, idempotencyKey: prepareRes.idempotencyKey }),
+      )
+
       // 금액 일치 검증 (백엔드 값끼리만 비교)
       const expectedTotal = prepareRes.totalProductPrice + prepareRes.deliveryFee - prepareRes.discountPrice
       if (prepareRes.totalPaymentPrice !== expectedTotal) {
@@ -301,6 +310,9 @@ export function PaymentPage() {
       showPopUp(getPaymentErrorMessage(err))
       await cleanupPendingPayment('CONFIRM_FAILED')
     } finally {
+      // PC 결제창 흐름(성공/취소/예외)에서는 같은 페이지에서 종료되므로 여기서 sessionStorage 정리.
+      // 모바일 redirect 흐름은 finally 가 실행되지 않고 PaymentCallbackPage 가 정리한다.
+      sessionStorage.removeItem(PENDING_PAYMENT_STORAGE_KEY)
       // 어떤 종료 경로(성공/취소/예외)에서도 결제버튼 잠금 해제 보장
       setIsPortOneOpen(false)
     }

--- a/frontend/src/pages/PaymentPage.tsx
+++ b/frontend/src/pages/PaymentPage.tsx
@@ -16,12 +16,16 @@ interface PortOnePaymentRequest {
   currency: string
   payMethod: string
   easyPay?: { easyPayProvider: string }
+  redirectUrl?: string
   customer: {
     email: string
     fullName: string
     phoneNumber: string
   }
 }
+
+// 카톡/인스타/페이스북/라인/네이버 인앱 브라우저 — PortOne 결제는 외부 앱 스킴 호출에 의존하므로 인앱 환경에서 차단됨.
+const IN_APP_BROWSER_REGEX = /KAKAOTALK|Instagram|FBAN|FBAV|Line|NAVER\(inapp/i
 
 import { useUser } from '@/features/auth/hooks'
 import { useCart } from '@/features/cart/hooks'
@@ -163,6 +167,11 @@ export function PaymentPage() {
     e.preventDefault()
     if (checkoutItems.length === 0 || !address || !resolvedShippingId) return
 
+    if (IN_APP_BROWSER_REGEX.test(navigator.userAgent)) {
+      showPopUp('인앱 브라우저에서는 결제가 제한됩니다. Safari나 Chrome 등 기본 브라우저로 열어주세요.')
+      return
+    }
+
     const backendMethod = PAYMENT_METHOD_MAP[selectedMethod]
     if (!backendMethod) return
 
@@ -225,6 +234,9 @@ export function PaymentPage() {
         currency: 'KRW',
         payMethod: backendMethod === 'CARD' ? 'CARD' : 'EASY_PAY',
         ...(easyPayProvider && { easyPay: { easyPayProvider } }),
+        // 모바일 결제 시 PortOne 은 외부 앱·새 탭으로 빠졌다가 redirectUrl 로 복귀한다.
+        // PC 결제창은 이 옵션을 무시한다. 누락 시 모바일에서 결제창이 거부될 수 있어 항상 지정.
+        redirectUrl: `${window.location.origin}/payment/callback`,
         customer: {
           email: user?.email || 'buyer@myfave.com',
           fullName: user?.nickname || '구매자',


### PR DESCRIPTION
📌 관련 이슈

  Closes #192

  📝 작업 내용

  iPhone Safari(myfave.shop 프로덕션)에서 카드 결제 시
  [INIStdPay / Dev. Error] 모달이 떠 결제가 진행되지
  않는 문제를 해결합니다. 원인은 백엔드
  /payments/prepare가 디바이스에 관계없이 KG이니시스 PC
   전용 INIStdPay channelKey를 반환하고, 프론트도
  모바일 redirect 흐름(redirectUrl, 콜백 라우트, 인앱
  브라우저 차단)을 갖추지 않았기 때문입니다. 본 PR은
  프론트가 deviceType을 전달 → 백엔드가 PC/모바일
  channelKey 분기 → 프론트가 모바일 redirect/콜백을
  받아 confirm까지 전 구간을 정비합니다.

  🔍 변경 사항

  - [x] 기능 추가 (백엔드 deviceType 분기,
  /payment/callback 라우트, 모바일 결제 복귀 페이지)
  - [x] 버그 수정 (모바일 결제 차단, redirectUrl 누락,
  인앱 브라우저 무방어)
  - [ ] 리팩토링
  - [ ] 테스트 추가 / 수정
  - [ ] 문서 수정
  - [ ] 기타

  💡 구현 방법 / 주요 변경 포인트

  Backend (4 commits)

  - application.yml / application-local.yml:
  portone.channel-key에 mobile-card / mobile-kakao-pay
  / mobile-naver-pay / mobile-toss-pay 4종 추가
  (MOBILE_PORTONE_CHANNEL_KEY_* 환경변수 매핑).
  - PaymentPrepareRequest.java: inner enum DeviceType {
   PC, MOBILE } + 옵셔널 deviceType 필드. null = PC
  폴백이라 기존 클라이언트 호환.
  - PaymentService.java: 모바일 4개 @Value 필드 주입,
  resolveChannelKey(PaymentMethod, DeviceType) 시그니처
   확장. MOBILE이면 모바일 키, 그 외(null/PC)는 기존 PC
   키 반환.

  Frontend (6 commits)

  - PaymentPage.tsx
    - PortOne.requestPayment에 redirectUrl:
  ${origin}/payment/callback 추가 (PC는 무시,
  모바일에서 필수).
    - 인앱 브라우저(KAKAOTALK / Instagram / FBAN / FBAV
   / Line / NAVER inapp) 감지 시 결제 시도 차단 + 외부
  브라우저 안내 PopUp.
    - prepare 직후 sessionStorage에 { paymentId,
  idempotencyKey } 보존 (모바일 redirect 후 React
  state가 날아가는 문제 해결).
    - prepare 요청 body에 deviceType: MOBILE | PC 추가
  (/iPhone|iPad|iPod|Android/i userAgent 기반 — 화면
  너비 기준 useIsMobile은 PC에서 좁은 창 false positive
   위험이 있어 사용하지 않음).
  - PaymentCallbackPage.tsx (신규): query string의
  code/message/txId 파싱 → 성공이면 sessionStorage에서
  backend paymentId 복구 후 confirmPayment → /orders로
  이동, 실패/취소면 silent cancel + PopUp → /payment로
  복귀. useRef로 StrictMode 이중 호출 방지.
  - router.tsx: ProtectedRoute 그룹에 /payment/callback
   등록.
  - features/payments/types.ts: DeviceType 타입 +
  PaymentPrepareRequest에 deviceType?: DeviceType 추가.

  커밋 10개 (작업규칙 — 파일 단위)

  7b66aa73 feat: [PaymentPage.tsx] prepare 요청에
  deviceType 전달 (userAgent 기반)
  3bdd445c feat: [types.ts] PaymentPrepareRequest 에
  deviceType 필드 추가
  c005702a feat: [PaymentService.java]
  resolveChannelKey 디바이스 분기 추가
  6591e2d6 chore: [application-local.yml] 모바일
  PortOne channel-key 4종 추가
  1bdf877b chore: [application.yml] 모바일 PortOne
  channel-key 4종 추가
  a71ac2e6 feat: [PaymentPrepareRequest.java] 디바이스
  분기용 deviceType 필드 추가
  a48a6848 feat: [router.tsx] /payment/callback 라우트
  등록
  7680b92a feat: [PaymentCallbackPage.tsx] 모바일 결제
  복귀 콜백 페이지 신규
  4d6f6ece fix: [PaymentPage.tsx] 모바일 redirect
  복귀용 paymentId sessionStorage 보존
  b27910e8 fix: [PaymentPage.tsx] PortOne redirectUrl
  옵션 추가 + 인앱 브라우저 결제 차단 안내

  ✅ 테스트 방법

  1. 환경 설정 (배포 전 사전 작업 필수)

  - PortOne 관리자 콘솔에서 KG이니시스
  모바일(MOBPay/INIMobile) 채널 4종 활성 + channelKey
  발급
  - 해당 channelKey 4개를 prod 백엔드 환경변수 MOBILE_P
  ORTONE_CHANNEL_KEY_{CARD,KAKAOPAY,NAVERPAY,TOSSPAY}에
   주입
  - KG이니시스 상점ID(MID)가 INIpayTest(테스트)가 아닌
  실서비스 ID인지 확인 (현재 prod에서 [Dev. Error]
  접두사 관측 → 테스트 MID 강하게 의심)

  2. 실행 방법

  # Backend
  cd backend
  JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-2
  1.jdk/Contents/Home ./gradlew bootRun

  # Frontend
  cd frontend && yarn dev

  3. 확인 사항

  ┌──────────────┬─────────────────────────────────┐
  │   시나리오   │            기대 동작            │
  ├──────────────┼─────────────────────────────────┤
  │ 모바일       │ 모바일 결제창 정상 표시 → 결제  │
  │ Safari →     │ 완료 → /payment/callback 복귀 → │
  │ 카드 결제    │  /orders 이동                   │
  ├──────────────┼─────────────────────────────────┤
  │ 모바일       │ 결제를 취소하셨습니다. PopUp →  │
  │ Safari →     │ /payment 복귀 → 백엔드 결제     │
  │ 결제 중 취소 │ PENDING cleanup                 │
  ├──────────────┼─────────────────────────────────┤
  │ 모바일 카톡  │                                 │
  │ 인앱         │ 인앱 브라우저에서는 결제가      │
  │ 브라우저 →   │ 제한됩니다… PopUp + 결제 중단   │
  │ 결제 클릭    │                                 │
  ├──────────────┼─────────────────────────────────┤
  │              │ 기존 PC INIStdPay 흐름 유지     │
  │ PC Chrome →  │ (회귀 없음 — deviceType: 'PC'   │
  │ 카드 결제    │ 전송, redirectUrl은 PC SDK가    │
  │              │ 무시)                           │
  ├──────────────┼─────────────────────────────────┤
  │ PC Chrome →  │ 기존 PC 흐름 유지               │
  │ 이지페이 3종 │                                 │
  ├──────────────┼─────────────────────────────────┤
  │ 백엔드 단위  │ JAVA_HOME=…temurin-21…          │
  │              │ ./gradlew build -x test exit 0  │
  ├──────────────┼─────────────────────────────────┤
  │ 프론트 단위  │ yarn lint && yarn build exit 0  │
  └──────────────┴─────────────────────────────────┘

  📸 스크린샷

  Before — iPhone Safari에서 카드 결제 시도 시 표시되던
   모달:
  [INIStdPay / Dev. Error]
  해당기기로는 정상적인 결제가 진행되지 않을 수
  있습니다.
  PC로 결제 진행을 부탁드립니다.
  (원본 스크린샷은 리뷰어가 요청 시 별도 공유)

  After — PortOne 콘솔/MID 인프라 작업 완료 후 모바일
  결제창 정상 호출 + 콜백 복귀 흐름 (실제 화면은 인프라
   작업 후 첨부 예정).

  ⚠️ 리뷰어에게 전달 사항

  1. 이 PR만으로는 결제가 정상화되지 않습니다. 위
  "테스트 방법 — 환경 설정" 3가지(콘솔 모바일 채널
  활성, prod 환경변수 주입, MID 실서비스 ID 확인)가
  운영 측에서 동반되어야 결제가 동작합니다. 코드 머지 ≠
   결제 정상화.
  2. [Dev. Error] 접두사 → 테스트 MID 의심. KG이니시스
  상점ID가 INIpayTest로 운영되고 있을 가능성이 매우
  높습니다. 본 PR과 별개로 반드시 확인 부탁드립니다.
  3. deviceType 분기 기준: 화면 너비(useIsMobile)가
  아닌 userAgent 기반으로 결정했습니다. 데스크탑에서
  창을 좁힌 사용자가 모바일 channelKey로 잘못 분기되어
  PG가 거부하는 false positive를 막기 위함입니다.
  4. sessionStorage 키 공유: PaymentPage.tsx와
  PaymentCallbackPage.tsx가 같은
  키(myfave:pendingPayment)를 쓰는데 상수로 분리하지
  않았습니다. 향후 다른 페이지에서 참조 필요 시
  shared/utils에 상수로 추출 권장.
  5. 카카오/네이버/토스페이 모바일 케이스: 실제 에러
  메시지를 확보하지 못해 카드 케이스와 동일한
  INIStdPay류 차단인지 별개 원인인지 미확정. 본 PR로는
  동일 처리되지만, 머지 후 모바일에서 4종 모두 검증
  부탁드립니다.
  6. PortOne webhook(noticeUrls) 미구성 시 위험: 모바일
   사용자가 결제 완료 직후 브라우저를 닫으면 confirm
  미호출로 결제만 승인되고 백엔드는 PENDING. 본 PR 범위
   밖이지만 백엔드 webhook 처리 여부 점검 권장.
  7. SDK 버전 노후 (@portone/browser-sdk@^0.1.6): 현
  안정판은 0.3.x. 회귀 위험으로 본 PR에서는 제외. 별도
  PR로 분리 권장.

  📋 셀프 체크리스트

  - [x] 코드 컨벤션을 준수했나요? (작업규칙: 파일 단위
  커밋 / 메시지 형식 / Co-Authored-By 금지 / push는
  사용자)
  - [x] 불필요한 주석/로그를 제거했나요? (주석은
  "why"만, 가설 검증용 console.log 없음)
  - [ ] 테스트를 작성/업데이트했나요? — 미작성 (기존
  PaymentServiceTest는
  mock(PaymentPrepareRequest.class)를 사용해
  getDeviceType()이 자연스럽게 null → PC 폴백을 타므로
  기존 테스트는 깨지지 않음. 모바일 분기 신규 테스트는
  별도 PR 권장)
  - [x] PR 제목이 명확한가요? — 권장: [FIX] 모바일
  PortOne 결제 오류 해결 (PC/모바일 channelKey 분기 +
  redirectUrl + 콜백 페이지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모바일 환경에서 최적화된 결제 경험 추가
  * 결제 후 콜백 처리 개선
  * 인앱 브라우저 환경 감지 및 안내 추가

* **Bug Fixes**
  * 상품 이미지 포맷 수정

* **Removed**
  * 로그인 페이지 데모 계정 안내 문구 제거

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->