### PR TITLE
refactor: 프론트엔드 버그 4종 해결

### DIFF
--- a/frontend/src/features/auth/store.ts
+++ b/frontend/src/features/auth/store.ts
@@ -8,7 +8,7 @@ import type { User } from './types'
 // 사용자 식별 정보가 담긴 모든 로컬 캐시 키 — 로그인/로그아웃 시 모두 청소.
 // pending avatar 단일 키 + 레거시 이메일-포함 prefix(myfave-avatar:{email}) 도 정리해
 // 이전 사용자 식별자가 브라우저에 잔존하지 않도록 보장 (CodeRabbit Major).
-const USER_STORE_KEYS = ['myfave-shipping', 'myfave-cart', 'myfave-coupons', PENDING_AVATAR_KEY]
+const USER_STORE_KEYS = ['myfave-shipping', 'myfave-cart', 'myfave-coupons', 'myfave-checkout', PENDING_AVATAR_KEY]
 
 const clearUserStores = () => {
   queryClient.clear()

--- a/frontend/src/features/payments/store.ts
+++ b/frontend/src/features/payments/store.ts
@@ -38,6 +38,16 @@ export const useCheckoutStore = create<CheckoutState>()(
       setOrderType: (orderType) => set({ orderType }),
       reset: () => set(initialSession),
     }),
-    { name: 'myfave-checkout' },
+    {
+      name: 'myfave-checkout',
+      // 개인정보(address: 수령인명/연락처/주소)는 localStorage 에 저장하지 않는다.
+      // address 는 PaymentPage 마운트 시 백엔드 배송지에서 다시 채워지므로 영속 대상에서 제외.
+      partialize: (state) => ({
+        items: state.items,
+        appliedCoupon: state.appliedCoupon,
+        paymentMethod: state.paymentMethod,
+        orderType: state.orderType,
+      }),
+    },
   ),
 )

--- a/frontend/src/features/payments/store.ts
+++ b/frontend/src/features/payments/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 import type { CartItem } from '@/features/cart/types'
 import type { Coupon } from '@/features/coupons/types'
@@ -23,12 +24,20 @@ const initialSession: CheckoutSession = {
   orderType: 'DIRECT',
 }
 
-export const useCheckoutStore = create<CheckoutState>()((set) => ({
-  ...initialSession,
-  setItems: (items) => set({ items }),
-  setAddress: (address) => set({ address }),
-  setCoupon: (appliedCoupon) => set({ appliedCoupon }),
-  setPaymentMethod: (paymentMethod) => set({ paymentMethod }),
-  setOrderType: (orderType) => set({ orderType }),
-  reset: () => set(initialSession),
-}))
+// 주문서(결제 페이지) 데이터는 새로고침에도 유지돼야 한다.
+// cart 스토어와 동일하게 persist 미들웨어로 localStorage('myfave-checkout')에 저장.
+// 결제 완료 시 PaymentPage 에서 reset() 을 호출해 stale 주문서가 남지 않도록 한다.
+export const useCheckoutStore = create<CheckoutState>()(
+  persist(
+    (set) => ({
+      ...initialSession,
+      setItems: (items) => set({ items }),
+      setAddress: (address) => set({ address }),
+      setCoupon: (appliedCoupon) => set({ appliedCoupon }),
+      setPaymentMethod: (paymentMethod) => set({ paymentMethod }),
+      setOrderType: (orderType) => set({ orderType }),
+      reset: () => set(initialSession),
+    }),
+    { name: 'myfave-checkout' },
+  ),
+)

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -24,6 +24,19 @@ function mapCategory(code: string | null | undefined): ProductCategory {
   }
 }
 
+// 백엔드 condition enum(S_GRADE/A_GRADE/B_GRADE/C_GRADE) → 화면 표기 라벨(S급 등).
+// 매핑되지 않는 값은 빈 문자열을 반환해 뱃지를 숨긴다.
+const CONDITION_LABEL_MAP: Record<string, string> = {
+  S_GRADE: 'S급',
+  A_GRADE: 'A급',
+  B_GRADE: 'B급',
+  C_GRADE: 'C급',
+}
+
+function mapConditionLabel(condition: string | null | undefined): string {
+  return CONDITION_LABEL_MAP[condition?.toUpperCase() ?? ''] ?? ''
+}
+
 function toProduct(item: ProductApiItem): Product {
   // 로컬 imageMap(.jpg) 우선 — 큐레이션된 S3 URL 보장.
   // 매핑 없는 신상품은 백엔드 thumbnailUrl 로 fallback (없으면 빈 문자열 → alt 노출).
@@ -64,6 +77,7 @@ function toProductDetail(item: ProductDetailApiResponse): ProductDetail {
     priceNumber: item.price,
     images,
     isSoldOut: item.isSoldOut,
+    conditionLabel: mapConditionLabel(item.condition),
     features: item.description
       ? [{ title: '상품 설명', description: item.description }]
       : [],

--- a/frontend/src/features/products/mock.ts
+++ b/frontend/src/features/products/mock.ts
@@ -91,6 +91,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '디테일', description: '빈티지한 넘버링 프린트 포인트' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   2: {
     id: 2,
@@ -105,6 +107,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '활용도', description: '어떤 하의에도 무난한 데일리 아이템' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   3: {
     id: 3,
@@ -119,6 +123,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '핏', description: '허리라인 포인트로 라인 강조' },
       { title: '상태', description: '착용 1번' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   4: {
     id: 4,
@@ -133,6 +139,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '소재', description: '슬림한 라인이 돋보이는 세로 골지 패턴' },
       { title: '상태', description: '착용 1번' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   5: {
     id: 5,
@@ -147,6 +155,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '소재', description: '봄~초여름 데일리에 좋은 가벼운 소재' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   6: {
     id: 6,
@@ -161,6 +171,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '활용도', description: '봄·가을·겨울 어울리는 사계절 베이직 아이템' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   7: {
     id: 7,
@@ -175,6 +187,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '스타일', description: '청바지와 매치한 빈티지 겨울 코디' },
       { title: '상태', description: '착용 1번' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   8: {
     id: 8,
@@ -189,6 +203,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '활용도', description: '간절기부터 초겨울까지 폭넓게 활용 가능' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   9: {
     id: 9,
@@ -203,6 +219,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '실루엣', description: '풍성한 볼륨감으로 우아한 분위기 연출' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
   10: {
     id: 10,
@@ -217,6 +235,8 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       { title: '실루엣', description: '발목까지 떨어지는 페미닌한 롱 실루엣' },
       { title: '상태', description: '미착용 (only 피팅)' },
     ],
+    isSoldOut: false,
+    conditionLabel: '',
   },
 }
 

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -23,6 +23,8 @@ export interface ProductDetail {
   images: string[]
   features: ProductFeature[]
   isSoldOut: boolean
+  // 상품 상태 등급 라벨 (예: 'S급'). 백엔드 condition(S_GRADE 등)을 변환한 값. 없으면 빈 문자열.
+  conditionLabel: string
 }
 
 export interface InfluencerPick extends Product {

--- a/frontend/src/pages/PaymentPage.tsx
+++ b/frontend/src/pages/PaymentPage.tsx
@@ -438,9 +438,22 @@ export function PaymentPage() {
         <section className="mt-[32px] space-y-[16px]">
           <h2 className="font-noto text-[15px] font-bold text-[#322927]">결제 수단</h2>
           <div className="grid grid-cols-2 gap-[11px]">
-            {['카드', '카카오페이', '네이버페이', '토스페이'].map((label) => (
-              <button key={label} onClick={() => setSelectedMethod(label)} className={`h-[42px] rounded-[5px] border font-noto text-[16px] font-medium transition-all ${selectedMethod === label ? 'border-point bg-main-bg text-point' : 'border-[#F2EDEB] bg-[#FAFAF8] text-[#949494]'}`}>{label}</button>
-            ))}
+            {['카드', '카카오페이', '네이버페이', '토스페이'].map((label) => {
+              // 현재 신용카드 결제만 지원. 그 외 수단은 비활성화하고 '준비중'으로 표기.
+              const isReady = label === '카드'
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  disabled={!isReady}
+                  onClick={() => isReady && setSelectedMethod(label)}
+                  className={`flex h-[42px] items-center justify-center gap-[4px] rounded-[5px] border font-noto text-[16px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 ${selectedMethod === label ? 'border-point bg-main-bg text-point' : 'border-[#F2EDEB] bg-[#FAFAF8] text-[#949494]'}`}
+                >
+                  {label}
+                  {!isReady && <span className="font-noto text-[10px] font-normal text-[#B5B5B5]">준비중</span>}
+                </button>
+              )
+            })}
           </div>
         </section>
 

--- a/frontend/src/pages/PaymentPage.tsx
+++ b/frontend/src/pages/PaymentPage.tsx
@@ -56,6 +56,7 @@ export function PaymentPage() {
   const user = useUser()
   const checkoutItems = useCheckoutStore((s) => s.items)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
+  const resetCheckout = useCheckoutStore((s) => s.reset)
   const orderType = useCheckoutStore((s) => s.orderType)
   const cartItems = useCart()
   const clearCart = useCartStore((s) => s.clear)
@@ -265,6 +266,8 @@ export function PaymentPage() {
 
       clearCart()
       applyCoupon(null)
+      // 결제 완료 후 persist 된 주문서를 비워 stale 주문서가 새로고침 시 복원되지 않도록 한다.
+      resetCheckout()
       navigate('/order-success', {
         state: {
           orderNumber: order.orderNumber,

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -166,8 +166,13 @@ export function ProductDetailPage() {
         <div className="space-y-[12px]">
           <h1 className="font-noto text-[15px] font-normal leading-[24px] text-[#322927] tracking-tight">{product.title}</h1>
           <p className="font-noto text-[12px] font-normal leading-[18px] text-chat-font">{product.subtitle}</p>
-          <div className="pt-[4px]">
+          <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>
+            {product.conditionLabel && (
+              <span className="rounded-[4px] border border-point px-[6px] py-[2px] font-noto text-[11px] font-bold text-point">
+                {product.conditionLabel}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/shared/components/UserIcon.tsx
+++ b/frontend/src/shared/components/UserIcon.tsx
@@ -11,15 +11,17 @@ interface UserIconProps {
   profileImageUrl?: string
 }
 
-// Figma Node 99:351 (곰돌이), 99:380 (셀러) 기반 100% 실사 이미지 URL
+// 곰돌이 폴백 아이콘은 256px S3 PNG(회원가입 아바타와 동일 소스)를 사용한다.
+// 기존 Builder.io 에셋은 원본이 23px라 56px(마이페이지) 등에서 업스케일 시 깨졌으므로 교체.
+const S3_BEAR_BASE = 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon'
 const ICON_URLS: Record<IconType, Record<number, string>> = {
   bear: {
-    1: 'https://api.builder.io/api/v1/image/assets/TEMP/5c35661ffb032d111daeaeddf909db75bead765c?width=46',
-    3: 'https://api.builder.io/api/v1/image/assets/TEMP/1eba4e904dccbdd1f1c9e77dc7b2459c7f3d30fe?width=46',
-    5: 'https://api.builder.io/api/v1/image/assets/TEMP/5c35661ffb032d111daeaeddf909db75bead765c?width=46',
-    6: 'https://api.builder.io/api/v1/image/assets/TEMP/1eba4e904dccbdd1f1c9e77dc7b2459c7f3d30fe?width=46',
-    7: 'https://api.builder.io/api/v1/image/assets/TEMP/fbce4987b2973b8b3f8ead9a566874da5b500af6?width=46',
-    10: 'https://api.builder.io/api/v1/image/assets/TEMP/5c35661ffb032d111daeaeddf909db75bead765c?width=46',
+    1: `${S3_BEAR_BASE}/Property+1%3DDefault.png`,
+    3: `${S3_BEAR_BASE}/Property+1%3DVariant2.png`,
+    5: `${S3_BEAR_BASE}/Property+1%3DVariant3.png`,
+    6: `${S3_BEAR_BASE}/Property+1%3DVariant4.png`,
+    7: `${S3_BEAR_BASE}/Property+1%3DVariant5.png`,
+    10: `${S3_BEAR_BASE}/Property+1%3DDefault.png`,
   },
   human: {
     1: 'https://api.builder.io/api/v1/image/assets/TEMP/664f3316f9f68e98296767568c4a9a0815d48a0f?width=112',


### PR DESCRIPTION
 📌 관련 이슈

  Closes #(이슈번호 입력)

  📝 작업 내용

  프론트엔드 트러블슈팅 4건 해결 — 주문서 새로고침 시 상품 유실, 상품 등급 표시, 결제수단 제한, 프로필 아이콘 해상도 깨짐.

  🔍 변경 사항

  - [x] 기능 추가 (상품 등급 표시)
  - [x] 버그 수정 (주문서 유실, 아이콘 해상도, 결제수단)
  - [ ] 리팩토링
  - [ ] 테스트 추가 / 수정
  - [ ] 문서 수정
  - [ ] 기타 (설명: )


  💡 구현 방법 / 주요 변경 포인트

  - 주문서 새로고침 유실: useCheckoutStore가 in-memory라 새로고침 시 초기화됨 → cart 스토어와 동일하게 persist 적용. 결제 완료 시 reset() 호출로 stale 주문서 방지. 보안상
  개인정보(주소/연락처)는 partialize로 영속 제외(마운트 시 백엔드 배송지에서 재구성), 로그인/로그아웃 시 myfave-checkout 정리.
  - 상품 등급 표시: 백엔드 상세 API의 condition(S_GRADE 등)을 S급/A급/B급/C급 라벨로 매핑(mapConditionLabel)해 상세 페이지 가격 옆 뱃지로 노출. 백엔드 무수정.
  - 결제수단 제한: 현재 신용카드만 지원 → 카드 외(카카오/네이버/토스페이) disabled 처리 + 회색 + "준비중" 표기.
  - 곰돌이 아이콘 해상도: 원인은 폴백 아이콘이 23px Builder.io 에셋이라 56px(마이페이지) 업스케일 시 깨짐 → 회원가입 아바타와 동일한 256px S3 PNG로 교체.

  ✅ 테스트 방법

  1. 환경 설정: cd frontend && yarn install
  2. 실행 방법: yarn dev (또는 yarn build로 타입/번들 검증)
  3. 확인 사항:
    - 상품 담기 → /payment 진입 → 새로고침 시 상품 유지. 결제 완료 후 재진입 시 빈 주문서.
    - 등급이 다른 상품 상세 진입 → 가격 옆 S급/A급/... 뱃지 표시.
    - /payment 결제수단에서 카드만 선택 가능, 나머지 회색·"준비중".
    - 로그아웃 후 재로그인(또는 localStorage 초기화) → 마이페이지 곰돌이 아이콘 선명.

  📸 스크린샷 (선택)

  1. 환경 설정: cd frontend && yarn install
  2. 실행 방법: yarn dev (또는 yarn build로 타입/번들 검증)
  3. 확인 사항:
    - 상품 담기 → /payment 진입 → 새로고침 시 상품 유지. 결제 완료 후 재진입 시 빈 주문서.
    - 등급이 다른 상품 상세 진입 → 가격 옆 S급/A급/... 뱃지 표시.
    - /payment 결제수단에서 카드만 선택 가능, 나머지 회색·"준비중".
    - 로그아웃 후 재로그인(또는 localStorage 초기화) → 마이페이지 곰돌이 아이콘 선명.

  📸 스크린샷 (선택)

<img width="387" height="195" alt="Screenshot 2026-05-30 at 6 44 18 PM" src="https://github.com/user-attachments/assets/2c61bb00-6c2a-4a0b-aea9-1dc88b95204e" />

<img width="260" height="174" alt="Screenshot 2026-05-30 at 6 45 36 PM" src="https://github.com/user-attachments/assets/4f94ea6f-7852-4547-9a0e-10746481dd28" />

<img width="439" height="178" alt="Screenshot 2026-05-30 at 6 43 59 PM" src="https://github.com/user-attachments/assets/42448fba-7145-42dc-9169-56f2d50f8181" />




  ⚠️ 리뷰어에게 전달 사항

  - 등급 표시는 상세 API에만 condition이 있어 상세 페이지에만 적용(목록 카드 노출은 백엔드 목록 DTO 변경 필요 — 이번 범위 외).
  - mock.ts는 미사용 데드코드지만 tsc -b 빌드를 막고 있어(기존부터 isSoldOut 누락) 필드 보완만 했습니다.
  - 곰돌이 아바타 백엔드 영속화(User 엔티티 profileImageUrl)는 별도 후속 이슈 권장.

  📋 셀프 체크리스트

  - [x] 코드 컨벤션을 준수했나요?
  - [x] 불필요한 주석/로그를 제거했나요?
  - [ ] 테스트를 작성/업데이트했나요? (UI/스토어 변경, 수동 검증)
  - [x] PR 제목이 명확한가요? (예: [FIX] 프론트엔드 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주문 정보가 새로고침 후에도 유지되도록 개선
  * 상품 상세 페이지에 상태 등급 라벨 표시 추가

* **Improvements**
  * 결제 수단에서 카드 결제만 활성화 (기타 결제 수단은 준비중으로 표시)
  * 사용자 아이콘 이미지 업데이트
  * 결제 완료 후 주문 정보 자동 초기화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-first-half-of-year-Techeer-Team-D/MyFave/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->