### PR TITLE
refactor: 프론트엔드 상품 사진 변경

### DIFF
--- a/backend/scripts/db/seed_products.sql
+++ b/backend/scripts/db/seed_products.sql
@@ -168,32 +168,22 @@ UPDATE products SET
 WHERE product_id = 10;
 
 -- =====================================================
--- 2) product_images 1~10: 기존 삭제 후 재시드 (대표 jpg + 단독 heic)
+-- 2) product_images 1~10: 기존 삭제 후 재시드 (jsDelivr 단독샷 1장)
 -- =====================================================
 
 DELETE FROM product_images WHERE product_id BETWEEN 1 AND 10;
 
 INSERT INTO product_images (product_id, image_url, sort_order, is_main, created_at, updated_at) VALUES
-(1,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(1,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(2,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(2,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(3,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top3_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(3,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(4,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top4_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(4,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(5,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top5_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(5,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top5_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(6,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top6_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(6,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top6_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(7,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',  1, true,  NOW(), NOW()),
-(7,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic', 2, false, NOW(), NOW()),
-(8,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',  1, true,  NOW(), NOW()),
-(8,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic', 2, false, NOW(), NOW()),
-(9,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true,  NOW(), NOW()),
-(9,  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',2, false, NOW(), NOW()),
-(10, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true,  NOW(), NOW()),
-(10, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',2, false, NOW(), NOW());
+(1, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(2, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(3, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg', 1, true, NOW(), NOW()),
+(4, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg', 1, true, NOW(), NOW()),
+(5, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top5_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg', 1, true, NOW(), NOW()),
+(6, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top6_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(7, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/outer1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(8, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/outer2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(9, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/bottom1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(10, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/bottom2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW());
 
 -- =====================================================
 -- 3) products 11~19: UPSERT (재실행 안전)
@@ -225,26 +215,21 @@ ON CONFLICT (product_id) DO UPDATE SET
 
 -- =====================================================
 -- 4) product_images 11~19: 삭제 후 재시드
---    - 11~14: 대표 .jpg + 단독 .heic (S3에 .jpg 존재 확인됨)
---    - 15~19: .heic 1장만 (S3에 .jpg 없음)
+----    - 11~19: jsDelivr 단독샷 .jpg/.jpeg 1장 (S3 삭제로 백업 저장소 사용)
 -- =====================================================
 
 DELETE FROM product_images WHERE product_id BETWEEN 11 AND 19;
 
 INSERT INTO product_images (product_id, image_url, sort_order, is_main, created_at, updated_at) VALUES
-(11, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top7_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',     1, true,  NOW(), NOW()),
-(11, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top7_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',    2, false, NOW(), NOW()),
-(12, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top8_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',     1, true,  NOW(), NOW()),
-(12, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top8_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',    2, false, NOW(), NOW()),
-(13, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top9_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',     1, true,  NOW(), NOW()),
-(13, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top9_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',    2, false, NOW(), NOW()),
-(14, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top10_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',    1, true,  NOW(), NOW()),
-(14, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top10_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   2, false, NOW(), NOW()),
-(15, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top11_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',   1, true,  NOW(), NOW()),
-(16, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic', 1, true,  NOW(), NOW()),
-(17, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic', 1, true,  NOW(), NOW()),
-(18, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/acc1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',    1, true,  NOW(), NOW()),
-(19, 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/acc2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.heic',    1, true,  NOW(), NOW());
+(11, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top7_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(12, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top8_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(13, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top9_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(14, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top10_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(15, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/top11_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(16, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/bottom3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(17, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/bottom4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(18, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/acc1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW()),
+(19, 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main/acc2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg', 1, true, NOW(), NOW());
 
 -- =====================================================
 -- 5) 시퀀스 보정 (명시 ID INSERT 후)

--- a/frontend/src/features/auth/avatars.ts
+++ b/frontend/src/features/auth/avatars.ts
@@ -2,17 +2,11 @@
 // 사용자(MyFave 운영자)가 AWS S3에 업로드한 PNG URL들을 아래 배열에 그대로 채워 넣으면
 // 신규 회원 가입 시점에 무작위 1개가 선택되어 user.profileImageUrl 로 저장된다.
 //
-// 사용자가 URL을 제공하기 전까지는 빈 배열을 유지 — getRandomAvatarUrl()이 undefined를 반환하고
-// UserIcon이 기존 fallback 아이콘을 그대로 보여주므로 앱이 깨지지 않는다.
+// 빈 배열이면 getRandomAvatarUrl()이 undefined를 반환하고 UserIcon이 기본 아바타(인라인 SVG)를 보여준다.
 //
-// 운영자(2026-05-24) 제공 — MyFave_user_icon 5종 (Default + Variant2~5).
-export const BEAR_AVATAR_S3_URLS: readonly string[] = [
-  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon/Property+1%3DDefault.png',
-  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon/Property+1%3DVariant2.png',
-  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon/Property+1%3DVariant3.png',
-  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon/Property+1%3DVariant4.png',
-  'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon/Property+1%3DVariant5.png',
-]
+// 2026-05-31: AWS S3 버킷 삭제로 곰돌이 아바타 PNG(MyFave_user_icon/*)가 전부 유실됨.
+// 백업 저장소에도 곰돌이 에셋이 없어 무작위 아바타 부여를 중단(빈 배열). 신규 회원은 기본 SVG 아바타 사용.
+export const BEAR_AVATAR_S3_URLS: readonly string[] = []
 
 // 회원가입 시 무작위 1개 URL을 반환. 풀이 비어있으면 undefined.
 export function getRandomAvatarUrl(): string | undefined {

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -11,7 +11,7 @@ import type {
   ProductDetailApiResponse,
 } from './types'
 
-// DAON'S PICK: 픽1~4.mp4 영상 순서와 매칭되는 상품 id (고정)
+// MY PICK: 픽1~4.png 순서와 매칭되는 상품 id (고정)
 // 1) 원오프 넘버링 티셔츠, 2) 브라운 무스탕 자켓, 3) 스트라이프 카디건, 4) 플라워 롱스커트
 const INFLUENCER_PICK_IDS = [1, 7, 2, 9] as const
 

--- a/frontend/src/features/products/imageMap.ts
+++ b/frontend/src/features/products/imageMap.ts
@@ -1,10 +1,16 @@
 // 데이터 출처: frontend/상품 정보.md
-// 백엔드 응답의 thumbnailUrl/images[].imageUrl을 신뢰하지 않고 프론트엔드에서 S3 URL을 직접 매핑한다.
+// 백엔드 응답의 thumbnailUrl/images[].imageUrl을 신뢰하지 않고 프론트엔드에서 이미지 URL을 직접 매핑한다.
 // 관련 spec: .omc/specs/deep-interview-frontend-image-broken.md
 //
-// 2026-05-24: 운영자가 모든 사진2 의 확장자를 .heic → .jpg/.jpeg 로 재업로드.
-// 더 이상 클라이언트 측 heic2any 변환이 필요하지 않음. 필드 이름(`jpg`/`heic`) 은 호출처 영향 회피를 위해
-// 그대로 두지만 의미적으로 jpg=대표사진 / heic=사진2 (두 번째 사진) 로 이해하면 된다.
+// 2026-05-31: AWS S3 버킷(myfave-team-bucket)이 삭제되어 모든 S3 URL이 깨짐.
+// 백업 저장소(github.com/2026-first-half-of-year-Techeer-Team-D/asset)를 jsDelivr CDN으로 서빙해 대체.
+// 저장소에는 '단독샷(사진2)'만 존재하고 '착용샷(대표/사진1)'은 없으므로 jpg(착용샷) 필드는 전부 null.
+// 파일명(한글)은 기존 S3와 동일한 NFD percent-인코딩을 그대로 사용한다(jsDelivr 200 확인).
+//
+// 필드 이름(`jpg`/`heic`)은 호출처 영향 회피를 위해 그대로 두지만 의미는 jpg=대표(현재 유실) / heic=단독샷(현재 대표 역할).
+
+const CDN = 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main'
+const d = '%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA' // 단독샷 (NFD)
 
 export interface ImageMapEntry {
   slug: string
@@ -13,103 +19,25 @@ export interface ImageMapEntry {
 }
 
 export const imageMap: Partial<Record<number, ImageMapEntry>> = {
-  1: {
-    slug: 'top1',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  2: {
-    slug: 'top2',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  3: {
-    slug: 'top3',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top3_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg',
-  },
-  4: {
-    slug: 'top4',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top4_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg',
-  },
-  5: {
-    slug: 'top5',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top5_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top5_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpeg',
-  },
-  6: {
-    slug: 'top6',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top6_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top6_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  7: {
-    slug: 'outer1',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  8: {
-    slug: 'outer2',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/outer2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  9: {
-    slug: 'bottom1',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom1_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  10: {
-    slug: 'bottom2',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom2_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  11: {
-    slug: 'top7',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top7_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  12: {
-    slug: 'top8',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top8_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top8_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  13: {
-    slug: 'top9',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top9_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top9_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  14: {
-    slug: 'top10',
-    jpg: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top10_%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top10_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  // id 15-19: 상품 정보.md 의 사진1(대표사진) 칸이 비어 있으므로 jpg=null. 사진2 는 .jpg 로 재업로드됨.
-  // getProductThumbnail() 의 `entry.jpg ?? entry.heic` fallback 으로 사진2 가 대표 이미지 역할.
-  15: {
-    slug: 'top11',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/top11_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  16: {
-    slug: 'bottom3',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom3_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  17: {
-    slug: 'bottom4',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/bottom4_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  18: {
-    slug: 'acc1',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/acc1_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
-  19: {
-    slug: 'acc2',
-    jpg: null,
-    heic: 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/acc2_%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA.jpg',
-  },
+  1: { slug: 'top1', jpg: null, heic: `${CDN}/top1_${d}.jpg` },
+  2: { slug: 'top2', jpg: null, heic: `${CDN}/top2_${d}.jpg` },
+  3: { slug: 'top3', jpg: null, heic: `${CDN}/top3_${d}.jpeg` },
+  4: { slug: 'top4', jpg: null, heic: `${CDN}/top4_${d}.jpeg` },
+  5: { slug: 'top5', jpg: null, heic: `${CDN}/top5_${d}.jpeg` },
+  6: { slug: 'top6', jpg: null, heic: `${CDN}/top6_${d}.jpg` },
+  7: { slug: 'outer1', jpg: null, heic: `${CDN}/outer1_${d}.jpg` },
+  8: { slug: 'outer2', jpg: null, heic: `${CDN}/outer2_${d}.jpg` },
+  9: { slug: 'bottom1', jpg: null, heic: `${CDN}/bottom1_${d}.jpg` },
+  10: { slug: 'bottom2', jpg: null, heic: `${CDN}/bottom2_${d}.jpg` },
+  11: { slug: 'top7', jpg: null, heic: `${CDN}/top7_${d}.jpg` },
+  12: { slug: 'top8', jpg: null, heic: `${CDN}/top8_${d}.jpg` },
+  13: { slug: 'top9', jpg: null, heic: `${CDN}/top9_${d}.jpg` },
+  14: { slug: 'top10', jpg: null, heic: `${CDN}/top10_${d}.jpg` },
+  15: { slug: 'top11', jpg: null, heic: `${CDN}/top11_${d}.jpg` },
+  16: { slug: 'bottom3', jpg: null, heic: `${CDN}/bottom3_${d}.jpg` },
+  17: { slug: 'bottom4', jpg: null, heic: `${CDN}/bottom4_${d}.jpg` },
+  18: { slug: 'acc1', jpg: null, heic: `${CDN}/acc1_${d}.jpg` },
+  19: { slug: 'acc2', jpg: null, heic: `${CDN}/acc2_${d}.jpg` },
 }
 
 export function getProductThumbnail(id: number): string {

--- a/frontend/src/features/products/mock.ts
+++ b/frontend/src/features/products/mock.ts
@@ -1,77 +1,81 @@
 import type { InfluencerPick, Product, ProductDetail } from './types'
 
-const S3 = 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com'
-const w = '%E1%84%8E%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%89%E1%85%A3%E1%86%BA' // 착용샷 (NFD)
+// 2026-05-31: AWS S3 버킷 삭제로 모든 이미지가 유실됨. 백업 저장소(asset)를 jsDelivr CDN으로 서빙.
+// 저장소에는 '단독샷'만 존재(착용샷 없음)하므로 mock 이미지도 단독샷 1장으로 통일한다.
+// 확장자: top3·top4·top5 만 .jpeg, 나머지는 .jpg (백업 저장소 실제 파일 기준).
+const CDN = 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main'
 const d = '%E1%84%83%E1%85%A1%E1%86%AB%E1%84%83%E1%85%A9%E1%86%A8%E1%84%89%E1%85%A3%E1%86%BA' // 단독샷 (NFD)
+const JPEG_SLUGS = new Set(['top3', 'top4', 'top5'])
+const solo = (slug: string) => `${CDN}/${slug}_${d}.${JPEG_SLUGS.has(slug) ? 'jpeg' : 'jpg'}`
 
 export const PRODUCTS: Product[] = [
   {
     id: 1,
     title: '원오프 넘버링 티셔츠',
-    image: `${S3}/top1_${w}.jpg`,
+    image: solo('top1'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 2,
     title: '스트라이프 카디건',
-    image: `${S3}/top2_${w}.jpg`,
+    image: solo('top2'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 3,
     title: '오프숄더 리본 니트',
-    image: `${S3}/top3_${w}.jpg`,
+    image: solo('top3'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 4,
     title: '스카이 골지 카디건',
-    image: `${S3}/top4_${w}.jpg`,
+    image: solo('top4'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 5,
     title: '살구 핑크 레이어드 셔츠',
-    image: `${S3}/top5_${w}.jpg`,
+    image: solo('top5'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 6,
     title: '배색 스트라이프 니트 카디건',
-    image: `${S3}/top6_${w}.jpg`,
+    image: solo('top6'),
     price: '10,000원',
     category: 'top',
   },
   {
     id: 7,
     title: '브라운 무스탕 자켓',
-    image: `${S3}/outer1_${w}.jpg`,
+    image: solo('outer1'),
     price: '30,000원',
     category: 'outer',
   },
   {
     id: 8,
     title: '블랙 퍼 카라 레더 자켓',
-    image: `${S3}/outer2_${w}.jpg`,
+    image: solo('outer2'),
     price: '30,000원',
     category: 'outer',
   },
   {
     id: 9,
     title: '플라워 롱스커트',
-    image: `${S3}/bottom1_${w}.jpg`,
+    image: solo('bottom1'),
     price: '10,000원',
     category: 'bottom',
   },
   {
     id: 10,
     title: '셔링 롱스커트',
-    image: `${S3}/bottom2_${w}.jpg`,
+    image: solo('bottom2'),
     price: '10,000원',
     category: 'bottom',
   },
@@ -85,7 +89,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '한쪽 어깨가 시원하게 드러나는 오프숄더 디자인의 화이트 긴팔 티셔츠예요. 빈티지한 느낌의 넘버링 프린트가 포인트로 들어가 캐주얼하면서도 트렌디한 무드를 연출해줍니다. 한 장만 입어도 데일리룩으로 완성도 있게 떨어져요!',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top1_${w}.jpg`, `${S3}/top1_${d}.heic`],
+    images: [solo('top1')],
     features: [
       { title: '디자인', description: '오프숄더 디자인의 화이트 긴팔 티셔츠' },
       { title: '디테일', description: '빈티지한 넘버링 프린트 포인트' },
@@ -101,7 +105,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '부드러운 촉감의 그레이 톤 스트라이프 카디건이에요. 두 가지 톤의 그레이가 차분하면서도 세련된 무드를 연출해줍니다. 데일리하게 걸치기 좋고 어떤 하의에도 무난하게 매치되더라구요.',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top2_${w}.jpg`, `${S3}/top2_${d}.heic`],
+    images: [solo('top2')],
     features: [
       { title: '컬러', description: '두 가지 톤의 차분하고 세련된 그레이 스트라이프' },
       { title: '활용도', description: '어떤 하의에도 무난한 데일리 아이템' },
@@ -117,7 +121,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '과하지 않은 레드 컬러에 한쪽 어깨를 리본으로 묶는 디자인이 사랑스러운 니트예요. 허리라인 포인트로 라인을 살려줍니다. 포인트 컬러로 코디에 생기를 더해주는 아이템!',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top3_${w}.jpg`, `${S3}/top3_${d}.heic`],
+    images: [solo('top3')],
     features: [
       { title: '디자인', description: '리본 오프숄더로 사랑스러운 무드 연출' },
       { title: '핏', description: '허리라인 포인트로 라인 강조' },
@@ -133,7 +137,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '은은한 스카이 컬러가 봄·여름 분위기에 딱 맞는 슬림핏 골지 카디건이에요. 세로 골지 패턴이 슬림한 라인을 더욱 돋보이게 해줍니다. 단독으로 입거나 이너로 활용해도 좋은 활용도 높은 아이템이에요.',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top4_${w}.jpg`, `${S3}/top4_${d}.heic`],
+    images: [solo('top4')],
     features: [
       { title: '컬러', description: '봄·여름에 어울리는 은은한 스카이 컬러' },
       { title: '소재', description: '슬림한 라인이 돋보이는 세로 골지 패턴' },
@@ -149,7 +153,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '은은한 살구빛 핑크 컬러의 레이어드 셔츠예요. 레이어드 디테일 덕에 단조롭지 않고 센스있는 느낌을 줍니다. 도톰하지 않은 가벼운 소재라 봄~초여름에 데일리로 입기 좋아요.',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top5_${w}.jpg`, `${S3}/top5_${d}.heic`],
+    images: [solo('top5')],
     features: [
       { title: '디테일', description: '단조롭지 않은 센스있는 레이어드 디테일' },
       { title: '소재', description: '봄~초여름 데일리에 좋은 가벼운 소재' },
@@ -165,7 +169,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '클래식한 마린룩 무드의 아이보리 베이스 블랙 스트라이프 카디건이에요. 탄탄한 짜임감으로 봄·가을·겨울에 따뜻하게 입기 좋고, 살짝 오버핏이라 편안하게 떨어집니다. 어떤 스타일에도 잘 녹아드는 베이직 아이템으로 추천해요!',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/top6_${w}.jpg`, `${S3}/top6_${d}.heic`],
+    images: [solo('top6')],
     features: [
       { title: '핏', description: '살짝 오버핏으로 편안하게 떨어지는 실루엣' },
       { title: '활용도', description: '봄·가을·겨울 어울리는 사계절 베이직 아이템' },
@@ -181,7 +185,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '포근한 안감과 브라운 외피가 조화로운 무스탕 자켓이에요. 카라와 소매 끝, 밑단까지 풍성한 무스탕이 둘러져 있어 보온성이 뛰어납니다. 청바지와 매치하면 빈티지한 무드의 겨울 코디 완성!',
     price: '30,000원',
     priceNumber: 30000,
-    images: [`${S3}/outer1_${w}.jpg`, `${S3}/outer1_${d}.heic`],
+    images: [solo('outer1')],
     features: [
       { title: '보온성', description: '카라·소매·밑단 둘러진 풍성한 무스탕 안감' },
       { title: '스타일', description: '청바지와 매치한 빈티지 겨울 코디' },
@@ -197,7 +201,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '탈부착 가능한 화이트 퍼 카라가 포인트인 블랙 레더 자켓이에요. 휘뚤마뚤 데일리하게 입기 좋아 더욱 매력적이구요! 간절기부터 초겨울까지 활용도 높게 입을 수 있어요.',
     price: '30,000원',
     priceNumber: 30000,
-    images: [`${S3}/outer2_${w}.jpg`, `${S3}/outer2_${d}.heic`],
+    images: [solo('outer2')],
     features: [
       { title: '디테일', description: '탈부착 가능한 화이트 퍼 카라 포인트' },
       { title: '활용도', description: '간절기부터 초겨울까지 폭넓게 활용 가능' },
@@ -213,7 +217,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '은은하게 비치는 시스루 소재에 플라워 자카드 패턴이 입체적으로 들어간 롱스커트예요. 풍성한 실루엣 덕분에 한 벌만 입어도 우아한 분위기가 연출됩니다. 특히 니트와 잘 어울리더라구요!',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/bottom1_${w}.jpg`, `${S3}/bottom1_${d}.heic`],
+    images: [solo('bottom1')],
     features: [
       { title: '소재', description: '시스루 소재에 입체적인 플라워 자카드 패턴' },
       { title: '실루엣', description: '풍성한 볼륨감으로 우아한 분위기 연출' },
@@ -229,7 +233,7 @@ export const PRODUCT_DETAILS: Record<number, ProductDetail> = {
       '은은한 광택감이 도는 블랙 컬러의 셔링 디테일 롱스커트예요. 자연스러운 주름이 풍성하게 떨어져 페미닌한 실루엣을 연출해줍니다. 발목까지 떨어지는 기장감으로 키와 상관없이 분위기 있게 소화할 수 있어요.',
     price: '10,000원',
     priceNumber: 10000,
-    images: [`${S3}/bottom2_${w}.jpg`, `${S3}/bottom2_${d}.heic`],
+    images: [solo('bottom2')],
     features: [
       { title: '디자인', description: '자연스럽게 풍성하게 떨어지는 셔링 주름 디테일' },
       { title: '실루엣', description: '발목까지 떨어지는 페미닌한 롱 실루엣' },
@@ -244,7 +248,7 @@ export const INFLUENCER_PICKS: InfluencerPick[] = [
   {
     id: 1,
     title: '원오프 넘버링 티셔츠',
-    image: `${S3}/top1_${w}.jpg`,
+    image: solo('top1'),
     price: '10,000원',
     category: 'top',
     rating: '4,283',
@@ -252,7 +256,7 @@ export const INFLUENCER_PICKS: InfluencerPick[] = [
   {
     id: 7,
     title: '브라운 무스탕 자켓',
-    image: `${S3}/outer1_${w}.jpg`,
+    image: solo('outer1'),
     price: '30,000원',
     category: 'outer',
     rating: '2,854',
@@ -260,7 +264,7 @@ export const INFLUENCER_PICKS: InfluencerPick[] = [
   {
     id: 2,
     title: '스트라이프 카디건',
-    image: `${S3}/top2_${w}.jpg`,
+    image: solo('top2'),
     price: '10,000원',
     category: 'top',
     rating: '3,314',
@@ -268,7 +272,7 @@ export const INFLUENCER_PICKS: InfluencerPick[] = [
   {
     id: 9,
     title: '플라워 롱스커트',
-    image: `${S3}/bottom1_${w}.jpg`,
+    image: solo('bottom1'),
     price: '10,000원',
     category: 'bottom',
     rating: '3,921',

--- a/frontend/src/pages/LiveChatPage.tsx
+++ b/frontend/src/pages/LiveChatPage.tsx
@@ -404,7 +404,7 @@ export function LiveChatPage() {
         <div className="flex flex-col gap-[17px]">
           {messages.map((msg) => (
             <div key={msg.id} className={`flex items-start gap-[8.5px] ${msg.isOfficial ? 'flex-row-reverse' : ''}`}>
-              <UserIcon type={msg.avatarType} variant={msg.avatarVariant} size={23.17} className="flex-shrink-0 mt-[1px]" />
+              <UserIcon type={msg.avatarType} variant={msg.avatarVariant} size="sm" className="flex-shrink-0 mt-[1px]" />
               <div className={`flex flex-col gap-[4.5px] ${msg.isOfficial ? 'items-end' : ''}`}>
                 <div className="flex items-center gap-[6px] px-[2px]">
                   <span className={`font-noto text-[12px] leading-[18px] text-[#000000] ${msg.isOfficial ? 'font-bold' : 'font-normal'}`}>

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -10,7 +10,7 @@ const CDN = 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/
 
 const MAIN_REEL = `${CDN}/%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%AB.png` // 메인.png
 
-const DAON_PICKS = [
+const MY_PICKS = [
   `${CDN}/%E1%84%91%E1%85%B5%E1%86%A81.png`, // 픽1.png
   `${CDN}/%E1%84%91%E1%85%B5%E1%86%A82.png`, // 픽2.png
   `${CDN}/%E1%84%91%E1%85%B5%E1%86%A83.png`, // 픽3.png
@@ -76,9 +76,9 @@ export function MainPage() {
         )}
       </div>
 
-      {/* 4. DAON'S PICK Section (Horizontal Scroll) */}
+      {/* 4. MY PICK Section (Horizontal Scroll) */}
       <div className="mx-auto max-w-md pt-[23.99px] pb-20">
-        <h2 className="px-[19.99px] mb-[15.99px] font-noto text-[16px] font-medium leading-[25.2px] text-dark-text tracking-tight uppercase">DAON'S PICK</h2>
+        <h2 className="px-[19.99px] mb-[15.99px] font-noto text-[16px] font-medium leading-[25.2px] text-dark-text tracking-tight uppercase">MY PICK</h2>
 
         {isLoading ? (
           <div className="flex gap-[12px] px-[19.99px]">
@@ -95,7 +95,7 @@ export function MainPage() {
             >
               <div className="relative mb-3 h-[288.06px] overflow-hidden rounded-[8px] bg-white border-0 shadow-sm">
                 <img
-                  src={DAON_PICKS[index % DAON_PICKS.length]}
+                  src={MY_PICKS[index % MY_PICKS.length]}
                   alt={product.title}
                   className="w-full h-full object-cover border-0"
                 />

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -4,15 +4,17 @@ import { useInfluencerPicks } from '@/features/products/hooks'
 import { LiveChatPreview } from '@/shared/components/LiveChatPreview'
 import { SmartImage } from '@/shared/components/SmartImage'
 
-const S3 = 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com'
+// 2026-05-31: S3 버킷 삭제로 영상(.mp4) 유실. 백업 저장소(asset)에는 정지 이미지(.png)만 있어
+// jsDelivr CDN의 메인/픽 PNG로 대체하고 <video> 대신 <img>로 렌더한다.
+const CDN = 'https://cdn.jsdelivr.net/gh/2026-first-half-of-year-Techeer-Team-D/asset@main'
 
-const MAIN_REEL = `${S3}/%E1%84%8E%E1%85%AC%E1%84%8C%E1%85%A9%E1%86%BC%E1%84%87%E1%85%A9%E1%86%AB.mp4`
+const MAIN_REEL = `${CDN}/%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%AB.png` // 메인.png
 
 const DAON_PICKS = [
-  `${S3}/%E1%84%91%E1%85%B5%E1%86%A81.mp4`,
-  `${S3}/%E1%84%91%E1%85%B5%E1%86%A82.mp4`,
-  `${S3}/%E1%84%91%E1%85%B5%E1%86%A83.mp4`,
-  `${S3}/%E1%84%91%E1%85%B5%E1%86%A84.mp4`,
+  `${CDN}/%E1%84%91%E1%85%B5%E1%86%A81.png`, // 픽1.png
+  `${CDN}/%E1%84%91%E1%85%B5%E1%86%A82.png`, // 픽2.png
+  `${CDN}/%E1%84%91%E1%85%B5%E1%86%A83.png`, // 픽3.png
+  `${CDN}/%E1%84%91%E1%85%B5%E1%86%A84.png`, // 픽4.png
 ]
 
 export function MainPage() {
@@ -30,12 +32,9 @@ export function MainPage() {
             <div className="h-[12px] w-[12px] rounded-full bg-[#FFBD2E] shadow-sm" />
             <div className="h-[12px] w-[12px] rounded-full bg-[#28C840] shadow-sm" />
           </div>
-          <video
+          <img
             src={MAIN_REEL}
-            autoPlay
-            muted
-            loop
-            playsInline
+            alt="MyFave 메인"
             className="w-full h-[595.72px] object-cover border-0"
           />
         </div>
@@ -95,12 +94,9 @@ export function MainPage() {
               className="group flex flex-col flex-shrink-0 w-[162.03px]"
             >
               <div className="relative mb-3 h-[288.06px] overflow-hidden rounded-[8px] bg-white border-0 shadow-sm">
-                <video
+                <img
                   src={DAON_PICKS[index % DAON_PICKS.length]}
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
+                  alt={product.title}
                   className="w-full h-full object-cover border-0"
                 />
               </div>

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -5,7 +5,6 @@ import { useLogout, useUser } from '@/features/auth/hooks'
 import { useMyCoupons } from '@/features/coupons/hooks'
 import { useOrdersQuery } from '@/features/orders/hooks'
 import type { OrderSummaryApiResponse } from '@/features/orders/types'
-import { UserIcon } from '@/shared/components/UserIcon'
 import { SaleEventModal } from '@/shared/components/SaleEventModal'
 
 type DashboardBucket = '입금확인' | '배송준비' | '배송중' | '배송완료'
@@ -81,14 +80,7 @@ export function MyPage() {
       />
       {/* 1. User Profile Section - Figma Node 99:1201 */}
       <div className="px-[19.99px] pt-[23.99px] pb-[19.99px]">
-        <div className="flex items-center gap-[14px]">
-          <UserIcon
-            type="bear"
-            variant={10}
-            size={56}
-            className="shadow-sm"
-            profileImageUrl={user?.profileImageUrl}
-          />
+        <div className="flex items-center">
           <div className="flex flex-col gap-[1.99px]">
             <h2 className="font-noto text-[16px] font-medium leading-[24px] text-[#322927] tracking-tight">
               {displayName}

--- a/frontend/src/shared/components/LiveChatPreview.tsx
+++ b/frontend/src/shared/components/LiveChatPreview.tsx
@@ -86,7 +86,7 @@ export function LiveChatPreview() {
               <UserIcon
                 type="bear"
                 variant={getVariantFromNickname(msg.senderNickname)}
-                size={23.17}
+                size="sm"
                 className="flex-shrink-0"
               />
               <div className="flex flex-col gap-[4px]">

--- a/frontend/src/shared/components/UserIcon.tsx
+++ b/frontend/src/shared/components/UserIcon.tsx
@@ -1,14 +1,22 @@
 
 type IconType = 'bear' | 'human' | 'seller'
 type Variant = number
+type IconSize = 'sm' | 'md' | 'lg'
 
 interface UserIconProps {
   type?: IconType
   variant?: Variant
   className?: string
-  size?: number
+  size?: IconSize
   // 사용자별 프로필 이미지 URL. 존재하면 type 매핑보다 우선.
   profileImageUrl?: string
+}
+
+// size 변형 → Tailwind 클래스 (sm 24px / md 40px / lg 56px). 인라인 스타일 대신 클래스로 일관 처리.
+const SIZE_CLASS: Record<IconSize, string> = {
+  sm: 'w-6 h-6',
+  md: 'w-10 h-10',
+  lg: 'w-14 h-14',
 }
 
 // 2026-05-31: S3 버킷 삭제로 곰돌이 아이콘(MyFave_user_icon/*.png)이 유실됨.
@@ -24,12 +32,9 @@ const ICON_URLS: Partial<Record<IconType, Record<number, string>>> = {
 }
 
 // 외부 의존 없는 중립 기본 아바타 (구 곰돌이 자리 대체).
-function DefaultAvatar({ size, className }: { size: number; className: string }) {
+function DefaultAvatar({ size, className }: { size: IconSize; className: string }) {
   return (
-    <div
-      className={`relative overflow-hidden rounded-full flex-shrink-0 bg-[#F1E9E3] ${className}`}
-      style={{ width: size, height: size }}
-    >
+    <div className={`relative overflow-hidden rounded-full flex-shrink-0 bg-[#F1E9E3] ${SIZE_CLASS[size]} ${className}`}>
       <svg viewBox="0 0 40 40" className="h-full w-full" role="img" aria-label="기본 프로필">
         <circle cx="20" cy="15" r="7" fill="#C9BBB0" />
         <path d="M6 36c0-7.7 6.3-14 14-14s14 6.3 14 14" fill="#C9BBB0" />
@@ -38,17 +43,14 @@ function DefaultAvatar({ size, className }: { size: number; className: string })
   )
 }
 
-export function UserIcon({ type = 'bear', variant = 1, className = '', size = 23.17, profileImageUrl }: UserIconProps) {
+export function UserIcon({ type = 'bear', variant = 1, className = '', size = 'sm', profileImageUrl }: UserIconProps) {
   // profileImageUrl 우선, 없으면 type 매핑. bear(기본) 또는 매핑 부재 시 인라인 SVG 기본 아바타.
   const iconUrl = profileImageUrl ?? ICON_URLS[type]?.[variant] ?? ICON_URLS[type]?.[1]
 
   if (!iconUrl) return <DefaultAvatar size={size} className={className} />
 
   return (
-    <div
-      className={`relative overflow-hidden rounded-full flex-shrink-0 ${className}`}
-      style={{ width: size, height: size }}
-    >
+    <div className={`relative overflow-hidden rounded-full flex-shrink-0 ${SIZE_CLASS[size]} ${className}`}>
       <img
         src={iconUrl}
         alt={`${type} icon`}

--- a/frontend/src/shared/components/UserIcon.tsx
+++ b/frontend/src/shared/components/UserIcon.tsx
@@ -7,33 +7,42 @@ interface UserIconProps {
   variant?: Variant
   className?: string
   size?: number
-  // 회원가입 시 부여된 사용자별 프로필 이미지 URL. 존재하면 type/variant 매핑보다 우선.
+  // 사용자별 프로필 이미지 URL. 존재하면 type 매핑보다 우선.
   profileImageUrl?: string
 }
 
-// 곰돌이 폴백 아이콘은 256px S3 PNG(회원가입 아바타와 동일 소스)를 사용한다.
-// 기존 Builder.io 에셋은 원본이 23px라 56px(마이페이지) 등에서 업스케일 시 깨졌으므로 교체.
-const S3_BEAR_BASE = 'https://myfave-team-bucket.s3.ap-northeast-2.amazonaws.com/MyFave_user_icon'
-const ICON_URLS: Record<IconType, Record<number, string>> = {
-  bear: {
-    1: `${S3_BEAR_BASE}/Property+1%3DDefault.png`,
-    3: `${S3_BEAR_BASE}/Property+1%3DVariant2.png`,
-    5: `${S3_BEAR_BASE}/Property+1%3DVariant3.png`,
-    6: `${S3_BEAR_BASE}/Property+1%3DVariant4.png`,
-    7: `${S3_BEAR_BASE}/Property+1%3DVariant5.png`,
-    10: `${S3_BEAR_BASE}/Property+1%3DDefault.png`,
-  },
+// 2026-05-31: S3 버킷 삭제로 곰돌이 아이콘(MyFave_user_icon/*.png)이 유실됨.
+// 백업 저장소에도 곰돌이 에셋이 없어, 기본 아바타는 외부 의존 없는 인라인 SVG로 대체한다.
+// human/seller 는 살아있는 builder.io 에셋을 그대로 사용한다. (variant 는 호출처 호환을 위해 유지)
+const ICON_URLS: Partial<Record<IconType, Record<number, string>>> = {
   human: {
     1: 'https://api.builder.io/api/v1/image/assets/TEMP/664f3316f9f68e98296767568c4a9a0815d48a0f?width=112',
   },
   seller: {
     1: 'https://api.builder.io/api/v1/image/assets/TEMP/10839d8a0a408e0bb7f424c267a2fb43e0feb3e4?width=46', // MyFave 공식 셀러 아이콘
-  }
+  },
+}
+
+// 외부 의존 없는 중립 기본 아바타 (구 곰돌이 자리 대체).
+function DefaultAvatar({ size, className }: { size: number; className: string }) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded-full flex-shrink-0 bg-[#F1E9E3] ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <svg viewBox="0 0 40 40" className="h-full w-full" role="img" aria-label="기본 프로필">
+        <circle cx="20" cy="15" r="7" fill="#C9BBB0" />
+        <path d="M6 36c0-7.7 6.3-14 14-14s14 6.3 14 14" fill="#C9BBB0" />
+      </svg>
+    </div>
+  )
 }
 
 export function UserIcon({ type = 'bear', variant = 1, className = '', size = 23.17, profileImageUrl }: UserIconProps) {
-  // profileImageUrl 이 있으면 그 S3 URL 을 우선 사용. 없으면 기존 type/variant 매핑.
-  const iconUrl = profileImageUrl ?? (ICON_URLS[type]?.[variant] || ICON_URLS[type]?.[1] || ICON_URLS['bear'][1])
+  // profileImageUrl 우선, 없으면 type 매핑. bear(기본) 또는 매핑 부재 시 인라인 SVG 기본 아바타.
+  const iconUrl = profileImageUrl ?? ICON_URLS[type]?.[variant] ?? ICON_URLS[type]?.[1]
+
+  if (!iconUrl) return <DefaultAvatar size={size} className={className} />
 
   return (
     <div


### PR DESCRIPTION
 📌 관련 이슈

  Closes #211

  📝 작업 내용
  
  AWS S3 버킷 삭제로 깨진 상품·메인·아바타 이미지를 GitHub asset 저장소(jsDelivr CDN)로 대체해 복구했습니다. 저장소에 없는 자산(착용샷·영상·곰돌이 아바타)은 단독샷/정지이미지/기본 아이콘으로 대체했고, 메인 섹션명을 daon's pick → 
  my pick으로 변경했습니다.

  🔍 변경 사항
  
  - [ ] 기능 추가
  - [x] 버그 수정
  - [x] 리팩토링
  - [ ] 테스트 추가 / 수정
  - [ ] 문서 수정
  - [x] 기타 (설명: UI/디자인 변경 — 아바타 칸 제거, 섹션명 변경)

  💡 구현 방법 / 주요 변경 포인트

  - 이미지 호스트만 교체: S3와 동일한 NFD 인코딩이라 경로는 그대로 두고 호스트만 cdn.jsdelivr.net/gh/...asset@main으로 치환.
  - 착용샷 유실: 저장소에 단독샷만 있어 imageMap.ts jpg=null 처리(단독샷이 대표) + seed_products.sql 단독샷 1장 재시드(stale .heic→실제 확장자 정정).
  - 메인/픽 영상 유실: .mp4 → 정지 이미지(메인.png/픽N.png), <video>→<img>.
  - 곰돌이 아바타 유실: UserIcon을 외부 의존 없는 인라인 SVG 기본 아바타로 교체, 마이페이지 아바타 칸 제거, 회원가입 무작위 아바타 부여 중단.

  ✅ 테스트 방법

  1. 환경 설정: cd frontend && yarn install
  2. 실행 방법: yarn dev (필요 시 backend seed_products.sql 재적용)
  3. 확인 사항:
    - 메인/상품목록/상품상세 이미지 정상 노출 (상품 1~14는 단독샷 1장)
    - 마이페이지 아바타 칸 제거 + 채팅 아바타가 기본 SVG로 표시
    - 메인 섹션 제목이 MY PICK으로 표시
    - yarn build 통과

  📸 스크린샷 (선택)

  (메인/마이페이지/채팅 전후 캡처 첨부 예정)

  ⚠️ 리뷰어에게 전달 사항
  
  - 착용샷(대표사진)은 영구 유실 — 저장소에 단독샷만 있어 상품 1~14는 사진 1장만 표시됩니다. 추후 착용샷 확보 시 asset 저장소 업로드 후 imageMap.ts의 jpg만 채우면 됩니다.
  - PENDING_AVATAR_KEY 정리 로직은 store.ts의 로그아웃 정리에서 사용하므로 제거하지 않고 avatars.ts 배열만 비웠습니다.
  - 인스타/유튜브 핸들(@daonmoood)은 브랜드 계정이라 유지했습니다.

  📋 셀프 체크리스트

  - [x] 코드 컨벤션을 준수했나요?
  - [x] 불필요한 주석/로그를 제거했나요?
  - [ ] 테스트를 작성/업데이트했나요? (해당 없음 — 에셋 URL 교체)
  - [x] PR 제목이 명확한가요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * S3 에셋 유실에 따른 이미지 호스팅 변경으로 상품 이미지와 아바타 손실 복구
  * 기본 아바타 렌더링 개선

* **UI/UX 개선**
  * 메인 배너 및 픽(Pick) 섹션에서 동영상을 정지 이미지로 변경
  * "DAON'S PICK"에서 "MY PICK"으로 섹션명 변경
  * 프로필 영역 레이아웃 최적화로 사용성 향상

* **데이터 업데이트**
  * 상품 이미지 및 모의 데이터 일관성 재정의

<!-- end of auto-generated comment: release notes by coderabbit.ai -->