### PR TITLE
fix: 배송 추적 페이지 null 크래시 수정

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -131,6 +131,7 @@ public class ShippingService {
                     .carrierId(delivery.getCarrierId())
                     .statusCode("DELIVERED")
                     .statusName("배송 완료")
+                    .events(List.of())
                     .build();
         }
 

--- a/frontend/src/features/shipping/types.ts
+++ b/frontend/src/features/shipping/types.ts
@@ -12,9 +12,9 @@ export interface Address {
 export interface TrackingEvent {
   statusCode: string
   statusName: string
-  time: string
-  location: string
-  description: string
+  time: string | null
+  location: string | null
+  description: string | null
 }
 
 export interface TrackingResponse {
@@ -25,5 +25,5 @@ export interface TrackingResponse {
   time: string
   location: string
   description: string
-  events: TrackingEvent[]
+  events: TrackingEvent[] | null
 }

--- a/frontend/src/pages/ShippingStatusPage.tsx
+++ b/frontend/src/pages/ShippingStatusPage.tsx
@@ -114,7 +114,7 @@ export function ShippingStatusPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {data.events.length === 0 ? (
+                  {(data.events ?? []).length === 0 ? (
                     <tr>
                       <td
                         colSpan={3}
@@ -124,13 +124,13 @@ export function ShippingStatusPage() {
                       </td>
                     </tr>
                   ) : (
-                    data.events.map((event, index) => (
+                    (data.events ?? []).map((event, index) => (
                       <tr
                         key={`${event.time}-${index}`}
                         className="border-b border-[#F2EDEB]/60 last:border-0"
                       >
                         <td className="py-[12px] pr-[8px] align-top font-noto text-[11px] text-dark-text leading-[16px] whitespace-pre-line">
-                          {format(new Date(event.time), 'yyyy-MM-dd\nHH:mm:ss')}
+                          {event.time ? format(new Date(event.time), 'yyyy-MM-dd\nHH:mm:ss') : '-'}
                         </td>
                         <td className="py-[12px] pr-[8px] align-top font-noto text-[12px] text-dark-text leading-[18px]">
                           {event.location ?? '-'}


### PR DESCRIPTION
## Summary

- `ShippingService.java`: DELIVERED 조기 반환 시 `.events(List.of())` 누락으로 `events: null` 직렬화 → 프론트 크래시 발생하던 버그 수정
- `types.ts`: tracker.delivery API가 일부 택배사(kr.cupost 등)에서 `time`, `location`, `description`을 null로 반환하는 현실 반영해 타입 수정
- `ShippingStatusPage.tsx`: `data.events ?? []` null 가드 추가, `time`이 null이면 `-` 표시

## Root Cause

`trackDelivery()`의 DELIVERED 조기 반환 경로에서 `TrackingResponse` builder에 `.events()` 호출이 없어 Lombok이 `null`로 초기화 → JSON 직렬화 시 `"events": null` → 프론트 `data.events.length` 에서 TypeError 발생

## Test plan

- [ ] DELIVERED 상태 주문 배송 추적 페이지 정상 렌더링 확인
- [ ] SHIPPING 상태 주문 배송 추적 페이지 정상 렌더링 확인
- [ ] `time: null` 이벤트에서 `-` 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배송 추적 조회 시 배송 완료 상태에서 배송 이력 데이터 일관성 개선
  * 배송 이력 정보 누락 시 화면에 적절한 플레이스홀더 표시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->