### PR TITLE
fix: 배송 단계 표시 오류 수정 (tracker UNKNOWN → DB status fallback)

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/dto/response/TrackingResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/dto/response/TrackingResponse.java
@@ -15,6 +15,7 @@ public class TrackingResponse {
     private String carrierId;
     private String statusCode;
     private String statusName;
+    private String deliveryStatus;
     private OffsetDateTime time;
     private String location;
     private String description;
@@ -30,7 +31,7 @@ public class TrackingResponse {
         private String description;
     }
 
-    public static TrackingResponse from(String carrierId,
+    public static TrackingResponse from(String carrierId, String deliveryStatus,
                                         TrackerDeliveryClient.TrackResult result) {
         TrackerDeliveryClient.EventData lastEvent = result.getLastEvent();
 
@@ -73,6 +74,7 @@ public class TrackingResponse {
                 .carrierId(carrierId)
                 .statusCode(statusCode)
                 .statusName(statusName)
+                .deliveryStatus(deliveryStatus)
                 .time(time)
                 .location(location)
                 .description(description)

--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -131,6 +131,7 @@ public class ShippingService {
                     .carrierId(delivery.getCarrierId())
                     .statusCode("DELIVERED")
                     .statusName("배송 완료")
+                    .deliveryStatus(DeliveryStatus.DELIVERED.name())
                     .events(List.of())
                     .build();
         }
@@ -145,6 +146,6 @@ public class ShippingService {
             order.completeDelivery();
         }
 
-        return TrackingResponse.from(delivery.getCarrierId(), result);
+        return TrackingResponse.from(delivery.getCarrierId(), delivery.getDeliveryStatus().name(), result);
     }
 }

--- a/frontend/src/features/shipping/types.ts
+++ b/frontend/src/features/shipping/types.ts
@@ -22,6 +22,7 @@ export interface TrackingResponse {
   carrierId: string
   statusCode: string
   statusName: string
+  deliveryStatus?: string
   time: string
   location: string
   description: string

--- a/frontend/src/pages/ShippingStatusPage.tsx
+++ b/frontend/src/pages/ShippingStatusPage.tsx
@@ -22,10 +22,12 @@ const STEPS = ['결제완료', '배송준비중', '배송중', '배송완료'] a
 
 // Tracker.delivery statusCode → 4-step 진행도 index.
 // 알 수 없는 코드는 1(배송준비중)로 안전 fallback.
-function getStepIndex(statusCode: string | undefined | null): number {
-  if (!statusCode) return 1
+function getStepIndex(statusCode: string | undefined | null, deliveryStatus?: string): number {
   if (statusCode === 'DELIVERED') return 3
-  if (['OUT_FOR_DELIVERY', 'SHIPPING', 'AT_HUB', 'IN_TRANSIT'].includes(statusCode)) return 2
+  if (statusCode && ['OUT_FOR_DELIVERY', 'SHIPPING', 'AT_HUB', 'IN_TRANSIT'].includes(statusCode)) return 2
+  // tracker statusCode가 UNKNOWN 등 미인식 값이면 DB delivery_status로 fallback
+  if (deliveryStatus === 'DELIVERED') return 3
+  if (deliveryStatus === 'SHIPPING') return 2
   return 1
 }
 
@@ -42,7 +44,7 @@ export function ShippingStatusPage() {
   const { orderId } = useParams()
   const { data, isLoading, error } = useTracking(orderId ? Number(orderId) : undefined)
 
-  const currentStep = getStepIndex(data?.statusCode)
+  const currentStep = getStepIndex(data?.statusCode, data?.deliveryStatus)
   const carrierLabel = data?.carrierId ? CARRIER_NAMES[data.carrierId] ?? data.carrierId : undefined
 
   return (


### PR DESCRIPTION
## Summary

- tracker.delivery가 일부 택배사(CU편의점택배 등)에서 `statusCode: UNKNOWN`을 반환해 배송 중임에도 항상 **배송준비중**으로 표시되던 문제 수정
- `TrackingResponse`에 `deliveryStatus` 필드 추가 — DB의 실제 배송 상태를 함께 내려줌
- 프론트 `getStepIndex`에서 tracker statusCode가 미인식 값일 때 `deliveryStatus`로 fallback 처리

## Root Cause

tracker.delivery GraphQL API가 `kr.cupost` 이벤트의 `statusCode`를 `UNKNOWN`으로 반환함.
기존 `getStepIndex`는 UNKNOWN을 처리하는 분기가 없어 항상 1(배송준비중)로 폴백.

## Fallback 우선순위

```
tracker statusCode → DELIVERED / IN_TRANSIT 등 인식 가능한 값이면 우선 사용
                  → UNKNOWN 등 미인식 값이면 DB deliveryStatus 사용
```

## Test plan

- [ ] CU편의점택배(kr.cupost) SHIPPING 주문 → 배송 단계 **배송중** 표시 확인
- [ ] DELIVERED 주문 → 배송 단계 **배송완료** 표시 확인
- [ ] CJ대한통운 등 정상 statusCode 반환 택배사 → 기존 동작 유지 확인