### PR TITLE
refactor: [TrackerDeliveryClient] block() 제거 → trackAsync() Mono 반환 전환

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
@@ -57,9 +57,9 @@ public class TrackerDeliveryClient {
                 .bodyValue(body)
                 .retrieve()
                 .bodyToMono(GraphQLResponse.class)
+                .subscribeOn(Schedulers.boundedElastic())
                 .switchIfEmpty(Mono.error(new CustomException(ErrorCode.TRACKING_API_ERROR)))
                 .timeout(Duration.ofSeconds(15))
-                .subscribeOn(Schedulers.boundedElastic())
                 .map(response -> {
                     if (response.getData() == null || response.getData().getTrack() == null) {
                         throw new CustomException(ErrorCode.TRACKING_API_ERROR);

--- a/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
@@ -57,11 +57,11 @@ public class TrackerDeliveryClient {
                 .bodyValue(body)
                 .retrieve()
                 .bodyToMono(GraphQLResponse.class)
+                .switchIfEmpty(Mono.error(new CustomException(ErrorCode.TRACKING_API_ERROR)))
                 .timeout(Duration.ofSeconds(15))
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(response -> {
-                    if (response == null || response.getData() == null
-                            || response.getData().getTrack() == null) {
+                    if (response.getData() == null || response.getData().getTrack() == null) {
                         throw new CustomException(ErrorCode.TRACKING_API_ERROR);
                     }
                     return response.getData().getTrack();

--- a/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -45,33 +47,28 @@ public class TrackerDeliveryClient {
             }
             """;
 
-    public TrackResult track(String carrierId, String trackingNumber) {
+    public Mono<TrackResult> trackAsync(String carrierId, String trackingNumber) {
         Map<String, Object> body = Map.of(
                 "query", TRACK_QUERY,
                 "variables", Map.of("carrierId", carrierId, "trackingNumber", trackingNumber)
         );
 
-        try {
-            GraphQLResponse response = trackerWebClient.post()
-                    .bodyValue(body)
-                    .retrieve()
-                    .bodyToMono(GraphQLResponse.class)
-                    .block(Duration.ofSeconds(15));
-
-            if (response == null || response.getData() == null
-                    || response.getData().getTrack() == null) {
-                throw new CustomException(ErrorCode.TRACKING_API_ERROR);
-            }
-
-            return response.getData().getTrack();
-
-        } catch (CustomException e) {
-            throw e;
-        } catch (WebClientResponseException e) {
-            throw new CustomException(ErrorCode.TRACKING_API_ERROR);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.TRACKING_API_ERROR);
-        }
+        return trackerWebClient.post()
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(GraphQLResponse.class)
+                .timeout(Duration.ofSeconds(15))
+                .subscribeOn(Schedulers.boundedElastic())
+                .map(response -> {
+                    if (response == null || response.getData() == null
+                            || response.getData().getTrack() == null) {
+                        throw new CustomException(ErrorCode.TRACKING_API_ERROR);
+                    }
+                    return response.getData().getTrack();
+                })
+                .onErrorMap(CustomException.class, e -> e)
+                .onErrorMap(e -> !(e instanceof CustomException),
+                            e -> new CustomException(ErrorCode.TRACKING_API_ERROR));
     }
 
     // ── GraphQL 응답 역직렬화용 inner class ────────────────────────

--- a/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/service/ShippingService.java
@@ -137,7 +137,8 @@ public class ShippingService {
         }
 
         TrackerDeliveryClient.TrackResult result =
-                trackerDeliveryClient.track(delivery.getCarrierId(), delivery.getTrackingNumber());
+                trackerDeliveryClient.trackAsync(delivery.getCarrierId(), delivery.getTrackingNumber())
+                        .block();
 
         TrackerDeliveryClient.EventData lastEvent = result.getLastEvent();
         if (lastEvent != null && lastEvent.getStatus() != null

--- a/backend/src/test/java/com/myfave/api/domain/shipping/service/DeliveryTrackingServiceTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/shipping/service/DeliveryTrackingServiceTest.java
@@ -21,12 +21,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import reactor.core.publisher.Mono;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
 class DeliveryTrackingServiceTest {

--- a/backend/src/test/java/com/myfave/api/domain/shipping/service/DeliveryTrackingServiceTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/shipping/service/DeliveryTrackingServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
 class DeliveryTrackingServiceTest {
@@ -85,7 +86,7 @@ class DeliveryTrackingServiceTest {
 
         given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
         given(deliveryRepository.findByOrder(order)).willReturn(Optional.of(delivery));
-        given(trackerDeliveryClient.track("kr.cupost", "1234567890")).willReturn(result);
+        given(trackerDeliveryClient.trackAsync("kr.cupost", "1234567890")).willReturn(Mono.just(result));
 
         TrackingResponse response = shippingService.trackDelivery(USER_ID, ORDER_ID);
 
@@ -104,7 +105,7 @@ class DeliveryTrackingServiceTest {
 
         given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
         given(deliveryRepository.findByOrder(order)).willReturn(Optional.of(delivery));
-        given(trackerDeliveryClient.track("kr.cupost", "1234567890")).willReturn(result);
+        given(trackerDeliveryClient.trackAsync("kr.cupost", "1234567890")).willReturn(Mono.just(result));
 
         TrackingResponse response = shippingService.trackDelivery(USER_ID, ORDER_ID);
 
@@ -178,6 +179,6 @@ class DeliveryTrackingServiceTest {
         TrackingResponse response = shippingService.trackDelivery(USER_ID, ORDER_ID);
 
         assertThat(response.getStatusCode()).isEqualTo("DELIVERED");
-        verify(trackerDeliveryClient, never()).track(anyString(), anyString());
+        verify(trackerDeliveryClient, never()).trackAsync(anyString(), anyString());
     }
 }


### PR DESCRIPTION
## Summary

- `track()` → `trackAsync()` 로 메서드명 변경, 반환 타입 `Mono<TrackResult>`
- `.block(Duration.ofSeconds(15))` 제거 후 `.subscribeOn(Schedulers.boundedElastic()).timeout(Duration.ofSeconds(15))` 체인 반환
- `.switchIfEmpty(Mono.error(...))` 추가 — 빈 HTTP 응답 바디 시 NPE 방어
- `.onErrorMap()` 이중 체인으로 모든 비-CustomException → `TRACKING_API_ERROR` 래핑
- `ShippingService`: `trackAsync(...).block()` 호출 (JPA @Transactional 서비스에서 reactor 이벤트 루프 외부 블로킹)
- `DeliveryTrackingServiceTest`: mock stub 3곳 `Mono.just(result)` 반환으로 업데이트

## Closes

Closes #217

## Test plan

- [ ] `DeliveryTrackingServiceTest` 6개 케이스 PASS 확인
- [ ] `./gradlew build -x test` 성공 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **기능 개선**
  * 배송 추적 요청을 비동기 방식으로 전환해 응답 처리와 타임아웃 제어를 개선했습니다.
* **버그 수정**
  * 추적 결과가 없거나 오류 발생 시 일관된 배송 추적 오류로 처리하도록 강화했습니다.
  * 배송 완료 상태에서는 외부 추적 호출을 수행하지 않도록 검증을 보강했습니다.
* **테스트**
  * 비동기 추적 호출 방식에 맞춰 관련 테스트를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->