### PR TITLE
feat: [WebSocketConfig] JWT 핸드셰이크 인터셉터 활성화, /ws-test 엔드포인트 제거

### DIFF
--- a/backend/src/main/java/com/myfave/api/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/WebSocketConfig.java
@@ -26,14 +26,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                // TODO: 테스트 후 인터셉터 활성화
-                // .addInterceptors(jwtHandshakeInterceptor)
+                .addInterceptors(jwtHandshakeInterceptor)
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
-
-        // TODO: 테스트 전용 — 배포 전 제거
-        registry.addEndpoint("/ws-test")
-                .setAllowedOriginPatterns("*");
     }
 
     @Override


### PR DESCRIPTION
## Summary

- `.addInterceptors(jwtHandshakeInterceptor)` 주석 해제 — SockJS 핸드셰이크 시 JWT 토큰 검증 활성화
- `/ws-test` 테스트 전용 엔드포인트 블록 삭제 (배포 전 제거 TODO 완료)
- `jwtChannelInterceptor`(`configureClientInboundChannel`)는 변경 없음

## Closes

Closes #219

## Test plan

- [ ] `./gradlew build -x test` 성공 확인
- [ ] `/ws` 엔드포인트로 SockJS 연결 시 JWT 없으면 핸드셰이크 거부 확인
- [ ] `/ws-test` 엔드포인트 삭제 확인 (404)

