### PR TITLE
feat: [axios] 세션 만료 시 toast 알림 + 선택적 스토어 정리로 UX 개선

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-intersection-observer": "^10.0.3",
     "react-router-dom": "^7.14.1",
     "sockjs-client": "^1.6.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { Toaster } from 'sonner'
 
 import { queryClient } from './queryClient'
 
@@ -10,6 +11,7 @@ export function Providers({ children }: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       {children}
       <ReactQueryDevtools initialIsOpen={false} />
+      <Toaster richColors position="top-center" />
     </QueryClientProvider>
   )
 }

--- a/frontend/src/shared/api/axios.ts
+++ b/frontend/src/shared/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { toast } from 'sonner'
 
 import { useAuthStore } from '@/features/auth/store'
 
@@ -58,7 +59,8 @@ apiClient.interceptors.response.use(
           originalRequest.headers.Authorization = `Bearer ${data.data.accessToken}`
           return apiClient(originalRequest)
         } catch {
-          localStorage.clear()
+          toast.error('세션이 만료되었습니다. 다시 로그인해주세요.')
+          useAuthStore.getState().logout()
           window.location.href = '/login'
         }
       }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2862,6 +2862,11 @@ sockjs-client@^1.6.1:
     inherits "^2.0.4"
     url-parse "^1.5.10"
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"


### PR DESCRIPTION
## Summary

- `sonner@2.0.7` 설치
- `providers.tsx`: `<Toaster richColors position="top-center" />` 마운트
- `axios.ts` catch 블록 교체:
  - `localStorage.clear()` → `useAuthStore.getState().logout()` (토큰 외 데이터 보존)
  - `toast.error('세션이 만료되었습니다. 다시 로그인해주세요.')` 추가로 사용자 알림

## Closes

Closes #220

## Test plan

- [ ] `yarn build` TypeScript 에러 0개 확인
- [ ] 401 재발급 실패 시 toast 알림 표시 확인
- [ ] 리다이렉트 후 myfave-shipping, myfave-cart 등 사용자 스토어 키 유지 확인 (myfave-auth만 초기화)

