### PR TITLE
fix: [TrackerDeliveryClient] GraphQL errors 필드 파싱 및 예외 처리 추가

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
+++ b/backend/src/main/java/com/myfave/api/domain/shipping/client/TrackerDeliveryClient.java
@@ -61,6 +61,9 @@ public class TrackerDeliveryClient {
                 .timeout(Duration.ofSeconds(15))
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(response -> {
+                    if (response.getErrors() != null && !response.getErrors().isEmpty()) {
+                        throw new CustomException(ErrorCode.TRACKING_API_ERROR);
+                    }
                     if (response.getData() == null || response.getData().getTrack() == null) {
                         throw new CustomException(ErrorCode.TRACKING_API_ERROR);
                     }
@@ -76,6 +79,7 @@ public class TrackerDeliveryClient {
     @Getter @Setter @JsonIgnoreProperties(ignoreUnknown = true)
     public static class GraphQLResponse {
         private DataBody data;
+        private List<Map<String, Object>> errors;
     }
 
     @Getter @Setter @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
## Summary

- `GraphQLResponse` inner class에 `List<Map<String, Object>> errors` 필드 추가
- `trackAsync()` `.map()` 람다에서 data null 체크 이전에 errors 체크 삽입
  ```java
  if (response.getErrors() != null && !response.getErrors().isEmpty()) {
      throw new CustomException(ErrorCode.TRACKING_API_ERROR);
  }
  ```

## Depends on

- #224 (Task 1: trackAsync 전환) — `feat/task1-tracker-async` 브랜치 기반

## Closes

Closes #221

## Test plan

- [ ] GraphQL errors 포함 응답 시 `TRACKING_API_ERROR` 예외 발생 확인
- [ ] 정상 응답 시 기존 동작 유지 확인

