### PR TITLE
fix: [AuthService] reissue 시 구 refresh token 즉시 삭제로 Rotation 완성

### DIFF
--- a/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/myfave/api/domain/auth/service/AuthService.java
@@ -194,6 +194,7 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
+        redisTemplate.delete("refresh:" + userId);
         redisTemplate.opsForValue().set(
                 "refresh:" + userId,
                 newRefreshToken,

--- a/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceReissueTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/auth/service/AuthServiceReissueTest.java
@@ -53,6 +53,7 @@ class AuthServiceReissueTest {
         // then
         assertThat(response.getAccessToken()).isEqualTo(NEW_ACCESS_TOKEN);
         assertThat(response.getRefreshToken()).isEqualTo(NEW_REFRESH_TOKEN);
+        verify(redisTemplate).delete("refresh:" + USER_ID);
         verify(valueOperations).set(eq("refresh:" + USER_ID), eq(NEW_REFRESH_TOKEN), anyLong(), any());
     }
 


### PR DESCRIPTION
## Summary

- `reissue()` 내부 새 토큰 set 직전에 구 토큰 즉시 삭제 추가
  ```java
  redisTemplate.delete("refresh:" + userId);  // 구 토큰 무효화
  redisTemplate.opsForValue().set("refresh:" + userId, newRefreshToken, ...);
  ```
- `AuthServiceReissueTest.reissue_success`에 rotation verify 추가
  ```java
  verify(redisTemplate).delete("refresh:" + USER_ID);
  ```

기존의 `storedToken.equals(token)` 체크가 탈취된 구 토큰 재사용을 1차 방어하고 있었으나, delete 추가로 진정한 Rotation 완성.

## Depends on

- #225 (Task 2: reissue 테스트) — `feat/task2-reissue-test` 브랜치 기반

## Closes

Closes #223

## Test plan

- [ ] `./gradlew test --tests "com.myfave.api.domain.auth.service.AuthServiceReissueTest"` 3개 PASS 확인


