### PR TITLE
Feat/content feed optimization

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-b-content.js
+++ b/backend/load-test/k6/scenarios/scenario-b-content.js
@@ -1,0 +1,111 @@
+// 시나리오 B — 콘텐츠 조회 폭증 (A-1 피드 최적화 측정용)
+// 기존 시나리오(A/D/E)는 Content를 전혀 때리지 않아 별도 추가.
+// 목적: N+1 제거·커서 페이징·첫 페이지 캐시의 before/after 효과 측정.
+// 지표: p95/p99 latency, 첫 페이지(캐시 후보) vs 깊은 페이지(DB) 대비.
+
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+import http from 'k6/http';
+
+import { get, BASE_URL } from '../lib/http.js';
+import { tokens } from '../lib/pool.js';
+
+http.setResponseCallback(http.expectedStatuses({ min: 200, max: 299 }));
+
+export const options = {
+  scenarios: {
+    content_read: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 50 },
+        { duration: '10s', target: 800 },
+        { duration: '3m', target: 800 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulRampDown: '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1000'],
+  },
+};
+
+// 첫 페이지(캐시 후보)와 깊은 페이지(DB)의 latency를 분리 측정
+const firstPageLatency = new Trend('content_first_page_latency', true);
+const deepPageLatency = new Trend('content_deep_page_latency', true);
+const errorBuckets = new Counter('content_errors_by_endpoint');
+
+const STYLE_SIZE = 12;
+const SHORT_SIZE = 10;
+
+// 가중치 — 첫 페이지에 트래픽 집중(캐시 효과 측정), 일부만 커서 따라 깊은 페이지
+const ENDPOINTS = [
+  { name: 'style-feeds:first', weight: 35 },
+  { name: 'style-feeds:deep', weight: 15 },
+  { name: 'short-forms:first', weight: 30 },
+  { name: 'short-forms:type', weight: 20 },
+];
+
+function pickEndpoint() {
+  const total = ENDPOINTS.reduce((s, e) => s + e.weight, 0);
+  const r = Math.random() * total;
+  let acc = 0;
+  for (const e of ENDPOINTS) {
+    acc += e.weight;
+    if (r < acc) return e.name;
+  }
+  return ENDPOINTS[0].name;
+}
+
+// 응답에서 nextCursor 추출 (다음 페이지 요청용)
+function nextCursorOf(res) {
+  try {
+    return JSON.parse(res.body)?.data?.nextCursor ?? null;
+  } catch (e) {
+    return null;
+  }
+}
+
+export function setup() {
+  console.log(`[scenario-B] BASE_URL=${BASE_URL}, 토큰 풀=${tokens.length}`);
+}
+
+export default function () {
+  const token = tokens[(__VU - 1) % tokens.length];
+  const accessToken = token.accessToken;
+  const endpoint = pickEndpoint();
+
+  let res;
+  let isFirstPage = true;
+
+  switch (endpoint) {
+    case 'style-feeds:first':
+      res = get(`/content/style-feeds?size=${STYLE_SIZE}`, accessToken);
+      break;
+    case 'style-feeds:deep': {
+      // 첫 페이지로 커서 확보 후 다음 페이지 조회 (DB 경로)
+      const head = get(`/content/style-feeds?size=${STYLE_SIZE}`, accessToken);
+      const cursor = nextCursorOf(head);
+      if (cursor == null) { res = head; break; }
+      isFirstPage = false;
+      res = get(`/content/style-feeds?size=${STYLE_SIZE}&cursor=${cursor}`, accessToken);
+      break;
+    }
+    case 'short-forms:first':
+      res = get(`/content/short-forms?size=${SHORT_SIZE}`, accessToken);
+      break;
+    case 'short-forms:type':
+      res = get(`/content/short-forms?size=${SHORT_SIZE}&type=PRODUCT_LIST`, accessToken);
+      break;
+  }
+
+  const ok = check(res, { 'status < 500': (r) => r.status < 500 });
+  if (!ok) errorBuckets.add(1, { endpoint });
+
+  if (isFirstPage) firstPageLatency.add(res.timings.duration);
+  else deepPageLatency.add(res.timings.duration);
+
+  sleep(Math.random() * 0.5);
+}

--- a/backend/load-test/k6/scenarios/scenario-b-content.js
+++ b/backend/load-test/k6/scenarios/scenario-b-content.js
@@ -101,11 +101,15 @@ export default function () {
       break;
   }
 
-  const ok = check(res, { 'status < 500': (r) => r.status < 500 });
-  if (!ok) errorBuckets.add(1, { endpoint });
-
-  if (isFirstPage) firstPageLatency.add(res.timings.duration);
-  else deepPageLatency.add(res.timings.duration);
+  // 13번 줄 expectedStatuses(2xx)와 기준 일치 — 성공 응답만 latency에 집계
+  const ok = check(res, { 'status 2xx': (r) => r.status >= 200 && r.status < 300 });
+  if (ok) {
+    if (isFirstPage) firstPageLatency.add(res.timings.duration);
+    else deepPageLatency.add(res.timings.duration);
+  } else {
+    // 실패는 status 태그로 분리 — latency 분포 오염 방지
+    errorBuckets.add(1, { endpoint, status: res.status });
+  }
 
   sleep(Math.random() * 0.5);
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
@@ -10,6 +10,7 @@ import com.myfave.api.global.common.ApiResponse;
 import com.myfave.api.global.common.CursorResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
@@ -33,7 +34,7 @@ public class ContentController {
     public ResponseEntity<ApiResponse<CursorResponse<ShortFormResponse>>> getShortForms(
             @RequestParam(required = false) ShortFormType type,
             @RequestParam(required = false) Long cursor,
-            @Min(1) @RequestParam(defaultValue = "10") int size) {
+            @Min(1) @Max(100) @RequestParam(defaultValue = "10") int size) {
         CursorResponse<ShortFormResponse> response = contentService.getShortForms(type, cursor, size);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
@@ -42,7 +43,7 @@ public class ContentController {
     @GetMapping("/style-feeds")
     public ResponseEntity<ApiResponse<CursorResponse<StyleFeedResponse>>> getStyleFeeds(
             @RequestParam(required = false) Long cursor,
-            @Min(1) @RequestParam(defaultValue = "12") int size) {
+            @Min(1) @Max(100) @RequestParam(defaultValue = "12") int size) {
         CursorResponse<StyleFeedResponse> response = contentService.getStyleFeeds(cursor, size);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }

--- a/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/controller/ContentController.java
@@ -7,20 +7,18 @@ import com.myfave.api.domain.content.dto.response.StyleFeedResponse;
 import com.myfave.api.domain.content.dto.response.ShortFormResponse;
 import com.myfave.api.domain.content.entity.ShortFormType;
 import com.myfave.api.global.common.ApiResponse;
+import com.myfave.api.global.common.CursorResponse;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/content")
@@ -30,21 +28,22 @@ public class ContentController {
 
     private final ContentService contentService;
 
-    // 9-1. 숏폼 목록 조회
+    // 9-1. 숏폼 목록 조회 (커서 페이징, cursor 미지정 시 첫 페이지)
     @GetMapping("/short-forms")
-    public ResponseEntity<ApiResponse<List<ShortFormResponse>>> getShortForms(
+    public ResponseEntity<ApiResponse<CursorResponse<ShortFormResponse>>> getShortForms(
             @RequestParam(required = false) ShortFormType type,
+            @RequestParam(required = false) Long cursor,
             @Min(1) @RequestParam(defaultValue = "10") int size) {
-        List<ShortFormResponse> response = contentService.getShortForms(type, size);
+        CursorResponse<ShortFormResponse> response = contentService.getShortForms(type, cursor, size);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    // 9-2. 스타일 피드 목록 조회
+    // 9-2. 스타일 피드 목록 조회 (커서 페이징, cursor 미지정 시 첫 페이지)
     @GetMapping("/style-feeds")
-    public ResponseEntity<ApiResponse<Page<StyleFeedResponse>>> getStyleFeeds(
-            @Min(0) @RequestParam(defaultValue = "0") int page,
+    public ResponseEntity<ApiResponse<CursorResponse<StyleFeedResponse>>> getStyleFeeds(
+            @RequestParam(required = false) Long cursor,
             @Min(1) @RequestParam(defaultValue = "12") int size) {
-        Page<StyleFeedResponse> response = contentService.getStyleFeeds(page, size);
+        CursorResponse<StyleFeedResponse> response = contentService.getStyleFeeds(cursor, size);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/backend/src/main/java/com/myfave/api/domain/content/dto/response/ShortFormResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/dto/response/ShortFormResponse.java
@@ -2,12 +2,15 @@ package com.myfave.api.domain.content.dto.response;
 
 import com.myfave.api.domain.content.entity.ShortForm;
 import com.myfave.api.domain.content.entity.ShortFormType;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // Redis 캐시 역직렬화용
 public class ShortFormResponse {
 
     private Long shortFormId;

--- a/backend/src/main/java/com/myfave/api/domain/content/dto/response/StyleFeedResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/dto/response/StyleFeedResponse.java
@@ -1,11 +1,14 @@
 package com.myfave.api.domain.content.dto.response;
 
 import com.myfave.api.domain.content.entity.StyleFeed;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // Redis 캐시 역직렬화용
 public class StyleFeedResponse {
 
     private Long styleFeedId;

--- a/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/repository/ShortFormRepository.java
@@ -5,6 +5,8 @@ import com.myfave.api.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.myfave.api.domain.content.entity.ShortFormType;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 
@@ -15,5 +17,15 @@ public interface ShortFormRepository extends JpaRepository<ShortForm, Long> {
     // 상품과 연결된 숏폼 목록
     List<ShortForm> findByProduct(Product product);
     List<ShortForm> findByDisplayType(ShortFormType displayType, Pageable pageable);
+
+    // 커서 기반 숏폼 조회 — Product까지 LEFT JOIN FETCH (BANNER는 product가 null이라 LEFT)
+    // type이 null이면 전체, cursor가 null이면 첫 페이지
+    @Query("SELECT s FROM ShortForm s LEFT JOIN FETCH s.product " +
+            "WHERE (:type IS NULL OR s.displayType = :type) " +
+            "AND (:cursor IS NULL OR s.shortFormId < :cursor) " +
+            "ORDER BY s.shortFormId DESC")
+    List<ShortForm> findByCursor(@Param("type") ShortFormType type,
+                                 @Param("cursor") Long cursor,
+                                 Pageable pageable);
 
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/repository/StyleFeedRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/repository/StyleFeedRepository.java
@@ -2,7 +2,10 @@ package com.myfave.api.domain.content.repository;
 
 import com.myfave.api.domain.content.entity.StyleFeed;
 import com.myfave.api.domain.product.entity.Product;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +13,11 @@ public interface StyleFeedRepository extends JpaRepository<StyleFeed, Long> {
 
     // 상품과 연결된 스타일 피드 목록
     List<StyleFeed> findByProduct(Product product);
+
+    // 커서 기반 피드 조회 — Product까지 JOIN FETCH (N+1 제거)
+    // cursor가 null이면 첫 페이지, 아니면 cursor 미만 id를 최신순 조회
+    @Query("SELECT sf FROM StyleFeed sf JOIN FETCH sf.product " +
+            "WHERE (:cursor IS NULL OR sf.styleFeedId < :cursor) " +
+            "ORDER BY sf.styleFeedId DESC")
+    List<StyleFeed> findByCursor(@Param("cursor") Long cursor, Pageable pageable);
 }

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -11,6 +11,7 @@ import com.myfave.api.domain.content.repository.ShortFormRepository;
 import com.myfave.api.domain.content.repository.StyleFeedRepository;
 import com.myfave.api.domain.product.entity.Product;
 import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.global.common.CursorResponse;
 import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import com.myfave.api.global.util.S3UploadService;
@@ -19,15 +20,13 @@ import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 @RequiredArgsConstructor
@@ -42,30 +41,27 @@ public class ContentService {
     @Value("${influencer.user-id}")
     private Long influencerUserId;
 
-    // 9-1. 숏폼 목록 조회
-    public List<ShortFormResponse> getShortForms(ShortFormType type, int size) {
-        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "shortFormId"));
-
-        List<ShortFormResponse> shortForms;
-
-        if (type != null) {
-            shortForms = shortFormRepository.findByDisplayType(type, pageable).stream()
-                    .map(ShortFormResponse::from)
-                    .toList();
-        } else {
-            shortForms = shortFormRepository.findAll(pageable).getContent().stream()
-                    .map(ShortFormResponse::from)
-                    .toList();
-        }
-
-        return shortForms;
+    // 9-1. 숏폼 목록 조회 (커서 페이징)
+    public CursorResponse<ShortFormResponse> getShortForms(ShortFormType type, Long cursor, int size) {
+        // hasNext 판별 위해 size+1개 조회
+        List<ShortForm> rows = shortFormRepository.findByCursor(type, cursor, PageRequest.of(0, size + 1));
+        return toCursorResponse(rows, size, ShortFormResponse::from, ShortForm::getShortFormId);
     }
 
-    // 9-2. 스타일 피드 목록 조회
-    public Page<StyleFeedResponse> getStyleFeeds(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "styleFeedId"));
-        return styleFeedRepository.findAll(pageable)
-                .map(StyleFeedResponse::from);
+    // 9-2. 스타일 피드 목록 조회 (커서 페이징)
+    public CursorResponse<StyleFeedResponse> getStyleFeeds(Long cursor, int size) {
+        List<StyleFeed> rows = styleFeedRepository.findByCursor(cursor, PageRequest.of(0, size + 1));
+        return toCursorResponse(rows, size, StyleFeedResponse::from, StyleFeed::getStyleFeedId);
+    }
+
+    // 커서 응답 변환 — size+1 조회분으로 hasNext 판별, 마지막 항목 id를 nextCursor로
+    private <E, R> CursorResponse<R> toCursorResponse(
+            List<E> rows, int size, Function<E, R> mapper, Function<E, Long> idExtractor) {
+        boolean hasNext = rows.size() > size;
+        List<E> page = hasNext ? rows.subList(0, size) : rows;
+        List<R> items = page.stream().map(mapper).toList();
+        Long nextCursor = page.isEmpty() ? null : idExtractor.apply(page.get(page.size() - 1));
+        return CursorResponse.of(items, nextCursor, hasNext);
     }
 
     // 9-3. 콘텐츠 등록

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -18,7 +18,6 @@ import com.myfave.api.global.util.S3UploadService;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -90,25 +89,26 @@ public class ContentService {
         return response;
     }
 
-    // 캐시 조회 — 손상/미스 시 null 반환해 DB 폴백
+    // 캐시 조회 — Redis 장애·역직렬화 실패 모두 캐시 미스로 처리해 DB 폴백
     private <R> CursorResponse<R> readCache(String key, Class<R> itemType) {
-        Object raw = redisTemplate.opsForValue().get(key);
-        if (raw == null) return null;
         try {
+            Object raw = redisTemplate.opsForValue().get(key);
+            if (raw == null) return null;
             JavaType type = CACHE_MAPPER.getTypeFactory()
                     .constructParametricType(CursorResponse.class, itemType);
             return CACHE_MAPPER.readValue(raw.toString(), type);
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
+            // Redis 다운(DataAccessException) 포함 — 조회는 DB로 폴백
             return null;
         }
     }
 
-    // 캐시 적재 — 실패해도 조회는 정상 동작하도록 예외 무시
+    // 캐시 적재 — Redis 장애·직렬화 실패해도 조회는 정상 동작하도록 예외 무시
     private void writeCache(String key, Object value) {
         try {
             redisTemplate.opsForValue().set(key, CACHE_MAPPER.writeValueAsString(value), FEED_CACHE_TTL);
-        } catch (JsonProcessingException e) {
-            // 캐싱 실패 무시
+        } catch (Exception e) {
+            // 캐싱 실패 무시 (Redis 다운 포함)
         }
     }
 
@@ -118,7 +118,8 @@ public class ContentService {
         boolean hasNext = rows.size() > size;
         List<E> page = hasNext ? rows.subList(0, size) : rows;
         List<R> items = page.stream().map(mapper).toList();
-        Long nextCursor = page.isEmpty() ? null : idExtractor.apply(page.get(page.size() - 1));
+        // 다음 페이지가 있을 때만 커서 발급 — 마지막 페이지는 null로 불필요 요청 차단
+        Long nextCursor = hasNext ? idExtractor.apply(page.get(page.size() - 1)) : null;
         return CursorResponse.of(items, nextCursor, hasNext);
     }
 

--- a/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
+++ b/backend/src/main/java/com/myfave/api/domain/content/service/ContentService.java
@@ -16,15 +16,24 @@ import com.myfave.api.global.error.CustomException;
 import com.myfave.api.global.error.ErrorCode;
 import com.myfave.api.global.util.S3UploadService;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
 import org.springframework.beans.factory.annotation.Value;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
 
@@ -37,21 +46,70 @@ public class ContentService {
     private final StyleFeedRepository styleFeedRepository;
     private final ProductRepository productRepository;
     private final S3UploadService s3UploadService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Value("${influencer.user-id}")
     private Long influencerUserId;
 
-    // 9-1. 숏폼 목록 조회 (커서 페이징)
+    // 첫 페이지 cache-aside TTL (짧게 둬서 등록 반영 지연 최소화, 무효화 로직 불필요)
+    private static final Duration FEED_CACHE_TTL = Duration.ofSeconds(10);
+
+    // 캐시 직렬화 전용 매퍼 — 필드 접근 허용해 별도 setter 없이 역직렬화
+    private static final ObjectMapper CACHE_MAPPER = JsonMapper.builder()
+            .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .build();
+
+    // 9-1. 숏폼 목록 조회 (커서 페이징, 첫 페이지만 캐싱)
     public CursorResponse<ShortFormResponse> getShortForms(ShortFormType type, Long cursor, int size) {
+        String cacheKey = cursor == null
+                ? "cache:content:short-forms:" + (type == null ? "all" : type.name()) + ":" + size
+                : null;
+        if (cacheKey != null) {
+            CursorResponse<ShortFormResponse> cached = readCache(cacheKey, ShortFormResponse.class);
+            if (cached != null) return cached;
+        }
         // hasNext 판별 위해 size+1개 조회
         List<ShortForm> rows = shortFormRepository.findByCursor(type, cursor, PageRequest.of(0, size + 1));
-        return toCursorResponse(rows, size, ShortFormResponse::from, ShortForm::getShortFormId);
+        CursorResponse<ShortFormResponse> response =
+                toCursorResponse(rows, size, ShortFormResponse::from, ShortForm::getShortFormId);
+        if (cacheKey != null) writeCache(cacheKey, response);
+        return response;
     }
 
-    // 9-2. 스타일 피드 목록 조회 (커서 페이징)
+    // 9-2. 스타일 피드 목록 조회 (커서 페이징, 첫 페이지만 캐싱)
     public CursorResponse<StyleFeedResponse> getStyleFeeds(Long cursor, int size) {
+        String cacheKey = cursor == null ? "cache:content:style-feeds:" + size : null;
+        if (cacheKey != null) {
+            CursorResponse<StyleFeedResponse> cached = readCache(cacheKey, StyleFeedResponse.class);
+            if (cached != null) return cached;
+        }
         List<StyleFeed> rows = styleFeedRepository.findByCursor(cursor, PageRequest.of(0, size + 1));
-        return toCursorResponse(rows, size, StyleFeedResponse::from, StyleFeed::getStyleFeedId);
+        CursorResponse<StyleFeedResponse> response =
+                toCursorResponse(rows, size, StyleFeedResponse::from, StyleFeed::getStyleFeedId);
+        if (cacheKey != null) writeCache(cacheKey, response);
+        return response;
+    }
+
+    // 캐시 조회 — 손상/미스 시 null 반환해 DB 폴백
+    private <R> CursorResponse<R> readCache(String key, Class<R> itemType) {
+        Object raw = redisTemplate.opsForValue().get(key);
+        if (raw == null) return null;
+        try {
+            JavaType type = CACHE_MAPPER.getTypeFactory()
+                    .constructParametricType(CursorResponse.class, itemType);
+            return CACHE_MAPPER.readValue(raw.toString(), type);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    // 캐시 적재 — 실패해도 조회는 정상 동작하도록 예외 무시
+    private void writeCache(String key, Object value) {
+        try {
+            redisTemplate.opsForValue().set(key, CACHE_MAPPER.writeValueAsString(value), FEED_CACHE_TTL);
+        } catch (JsonProcessingException e) {
+            // 캐싱 실패 무시
+        }
     }
 
     // 커서 응답 변환 — size+1 조회분으로 hasNext 판별, 마지막 항목 id를 nextCursor로

--- a/backend/src/main/java/com/myfave/api/global/common/CursorResponse.java
+++ b/backend/src/main/java/com/myfave/api/global/common/CursorResponse.java
@@ -1,0 +1,28 @@
+package com.myfave.api.global.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 커서(키셋) 기반 목록 응답
+ * offset 페이징과 달리 total 없이 다음 요청용 커서만 전달
+ * 무한스크롤 클라이언트는 hasNext가 true인 동안 nextCursor를 이어받아 요청
+ * NoArgsConstructor는 Redis 캐시 역직렬화(필드 접근)용
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CursorResponse<T> {
+
+    private List<T> items;
+    private Long nextCursor;
+    private boolean hasNext;
+
+    public static <T> CursorResponse<T> of(List<T> items, Long nextCursor, boolean hasNext) {
+        return new CursorResponse<>(items, nextCursor, hasNext);
+    }
+}

--- a/backend/src/test/java/com/myfave/api/domain/content/CursorResponseCacheSerdeTest.java
+++ b/backend/src/test/java/com/myfave/api/domain/content/CursorResponseCacheSerdeTest.java
@@ -1,0 +1,42 @@
+package com.myfave.api.domain.content;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.myfave.api.domain.content.dto.response.StyleFeedResponse;
+import com.myfave.api.global.common.CursorResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// ContentService 캐시 직렬화/역직렬화 라운드트립 검증 (제네릭 CursorResponse + DTO 필드 접근)
+class CursorResponseCacheSerdeTest {
+
+    private static final ObjectMapper CACHE_MAPPER = JsonMapper.builder()
+            .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+            .build();
+
+    @Test
+    void cursorResponse_라운드트립() throws Exception {
+        CursorResponse<StyleFeedResponse> origin = CursorResponse.of(
+                List.of(new StyleFeedResponse(2L, 100L, "url2"),
+                        new StyleFeedResponse(1L, 101L, "url1")),
+                1L, true);
+
+        String json = CACHE_MAPPER.writeValueAsString(origin);
+        JavaType type = CACHE_MAPPER.getTypeFactory()
+                .constructParametricType(CursorResponse.class, StyleFeedResponse.class);
+        CursorResponse<StyleFeedResponse> restored = CACHE_MAPPER.readValue(json, type);
+
+        assertThat(restored.isHasNext()).isTrue();
+        assertThat(restored.getNextCursor()).isEqualTo(1L);
+        assertThat(restored.getItems()).hasSize(2);
+        assertThat(restored.getItems().get(0).getStyleFeedId()).isEqualTo(2L);
+        assertThat(restored.getItems().get(0).getImageUrl()).isEqualTo("url2");
+        assertThat(restored.getItems().get(1).getProductId()).isEqualTo(101L);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #231 

## 📝 작업 내용
📝 작업 내용

Content 피드 조회(StyleFeed / ShortForm)를 트래픽 증가에도 버티도록 실커머스 방식으로 최적화 진행.  
N+1 제거, 커서(키셋) 페이징 전환, 첫 페이지 캐싱을 적용하고, 측정용 k6 시나리오를 추가

## 🔍 변경 사항

- [x] 기능 추가 (커서 페이징, 피드 캐싱)
- [x] 버그 수정 (getShortForms page=0 고정)
- [x] 리팩토링 (조회 쿼리 구조)
- [x] 테스트 추가 / 수정
- [ ] 문서 수정
- [x] 기타 (설명: k6 부하 시나리오 B 추가)

## 💡 구현 방법 / 주요 변경 포인트

- N+1 제거: StyleFeedRepository/ShortFormRepository에 JOIN FETCH로 Product까지 한 번에 가져오는 커서 조회 메서드 추가. ShortForm은 BANNER 타입의 product가 null이라 LEFT JOIN FETCH 사용.
- 커서(키셋) 페이징 전환: page/offset 대신 cursor(마지막 id) 기반 WHERE id < :cursor ORDER BY id DESC LIMIT n. 데이터가 쌓여도 뒷페이지 비용이 일정하고 무한스크롤에 적합. hasNext 판별을 위해 size+1개를 조회.
- 응답 통일: CursorResponse<T> { items, nextCursor, hasNext } 신규 도입. style-feeds는 기존 Page<>에서 변경.
- getShortForms 버그 수정: PageRequest.of(0, size) 하드코딩으로 첫 페이지만 나오던 문제를 커서 시그니처로 재작성하며 해결, 컨트롤러에 cursor 파라미터 추가.
- 첫 페이지 cache-aside: cursor == null인 첫 페이지만 Redis에 캐싱(TTL 10초, 키 네임스페이스 cache:content:*). 등록 빈도가 낮아 별도 무효화 없이 짧은 TTL로 자동 갱신. 캐시 직렬화는 필드 접근 전용 ObjectMapper를 써서 별도 setter 없이 역직렬화.

## ✅ 테스트 방법

1. 환경 설정: docker-compose up -d (PostgreSQL, Redis), cd backend
2. 실행 방법: ./gradlew test --tests "*CursorResponseCacheSerdeTest" 로 캐시 직렬화 라운드트립 검증 → ./gradlew bootRun
3. 확인 사항:
  - GET /content/style-feeds?size=12 → 응답 data.nextCursor 확인 후, 그 값으로 ?cursor=<값> 재요청 시 다음 페이지가 이어지는지
  - GET /content/short-forms?cursor=...&type=PRODUCT_LIST 동작
  - 같은 첫 페이지 2회 호출 시 2번째가 캐시 히트(쿼리 미발생)
  - 쿼리 수: generate_statistics/SQL 로그로 피드 조회가 1~2쿼리로 줄었는지 (before/after)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 콘텐츠 목록 조회(짧은 영상/스타일 피드)가 커서 기반으로 변경되어 더 자연스럽고 안정적인 페이지 이동이 가능합니다.
  * 각 목록 응답에 `nextCursor`와 다음 페이지 존재 여부(`hasNext`)가 포함됩니다.
  * 첫 페이지 결과를 캐시하여 조회 응답을 빠르게 제공합니다.

* **Bug Fixes**
  * 페이지 전환 시 응답 처리 규칙이 정리되어 목록 응답의 일관성이 개선되었습니다.
  * 캐시 직렬화/역직렬화 안정성을 검증하는 테스트가 추가되었습니다.

* **Tests**
  * 커서 응답의 캐시(직렬화/역직렬화) 라운드트립을 확인하는 테스트가 추가되었습니다.

* **Chores**
  * 부하 테스트 시나리오가 콘텐츠 조회 트래픽/지표(실패율, 지연 p95, 엔드포인트별 에러)를 포함하도록 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->