### PR TITLE
Feat/product view counter

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-c-view-counter.js
+++ b/backend/load-test/k6/scenarios/scenario-c-view-counter.js
@@ -1,0 +1,56 @@
+// 시나리오 C — 상품 조회수 카운터 집중 (조회수 고도화 측정용)
+// 인기 상품 1개에 조회(POST view)를 몰아넣어 카운터 쓰기 경합을 유발.
+// 목적: counter-mode=db(조회마다 DB 직접 +1, 행 락 경합) vs redis(INCR, 락 없음) 대비.
+// 운영법: 백엔드 product.view.counter-mode 를 db / redis 로 바꿔가며 2회 측정 후 비교.
+// 지표: TPS(iterations), p99 latency. (DB write 횟수·락 대기는 서버 Prometheus/Hibernate 통계로 관측)
+
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import http from 'k6/http';
+
+import { post, BASE_URL } from '../lib/http.js';
+import { tokens } from '../lib/pool.js';
+
+http.setResponseCallback(http.expectedStatuses({ min: 200, max: 299 }));
+
+// 경합을 보려고 단일 인기 상품에 집중 (모든 VU가 같은 row/key를 때림)
+const HOT_PRODUCT_ID = __ENV.HOT_PRODUCT_ID || '1';
+
+export const options = {
+  scenarios: {
+    view_counter: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 100 },
+        { duration: '10s', target: 1000 },
+        { duration: '3m', target: 1000 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulRampDown: '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(99)<1000'],
+  },
+};
+
+const viewErrors = new Counter('view_counter_errors');
+
+export function setup() {
+  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}, 토큰 풀=${tokens.length}`);
+}
+
+export default function () {
+  // view 엔드포인트는 공개(permitAll)지만 헤더 일관성 위해 토큰 부착
+  const accessToken = tokens[(__VU - 1) % tokens.length].accessToken;
+
+  // 단일 인기 상품에 조회수 몰빵 — 카운터 쓰기 경합 집중
+  const res = post(`/products/${HOT_PRODUCT_ID}/view`, accessToken, {});
+
+  const ok = check(res, { 'status < 500': (r) => r.status < 500 });
+  if (!ok) viewErrors.add(1);
+
+  sleep(Math.random() * 0.3);
+}

--- a/backend/load-test/k6/scenarios/scenario-c-view-counter.js
+++ b/backend/load-test/k6/scenarios/scenario-c-view-counter.js
@@ -8,8 +8,7 @@ import { check, sleep } from 'k6';
 import { Counter } from 'k6/metrics';
 import http from 'k6/http';
 
-import { post, BASE_URL } from '../lib/http.js';
-import { tokens } from '../lib/pool.js';
+import { BASE_URL } from '../lib/http.js';
 
 http.setResponseCallback(http.expectedStatuses({ min: 200, max: 299 }));
 
@@ -39,15 +38,17 @@ export const options = {
 const viewErrors = new Counter('view_counter_errors');
 
 export function setup() {
-  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}, 토큰 풀=${tokens.length}`);
+  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}`);
 }
 
 export default function () {
-  // view 엔드포인트는 공개(permitAll)지만 헤더 일관성 위해 토큰 부착
-  const accessToken = tokens[(__VU - 1) % tokens.length].accessToken;
-
+  // view 엔드포인트는 공개(permitAll) — 인증 시드(tokens.json)와 분리해 무인증 POST
   // 단일 인기 상품에 조회수 몰빵 — 카운터 쓰기 경합 집중
-  const res = post(`/products/${HOT_PRODUCT_ID}/view`, accessToken, {});
+  const res = http.post(
+    `${BASE_URL}/products/${HOT_PRODUCT_ID}/view`,
+    null,
+    { headers: { 'Content-Type': 'application/json' } },
+  );
 
   const ok = check(res, { 'status < 500': (r) => r.status < 500 });
   if (!ok) viewErrors.add(1);

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -4,8 +4,10 @@ import com.myfave.api.domain.product.dto.request.ProductRequest;
 import com.myfave.api.domain.product.dto.request.ProductUpdateRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
+import com.myfave.api.domain.product.dto.response.ProductViewResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.service.ProductService;
+import com.myfave.api.domain.product.service.ProductViewService;
 import com.myfave.api.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,6 +30,7 @@ import java.util.Map;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductViewService productViewService;
 
     // 3-1. 상품 목록 조회
     @GetMapping
@@ -46,6 +49,14 @@ public class ProductController {
             @PathVariable Long productId) {
         ProductResponse.Detail response = productService.getProduct(productId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 3-7. 상품 조회수 증가 (Redis 누적, 비로그인 포함 공개)
+    @PostMapping("/{productId}/view")
+    public ResponseEntity<ApiResponse<ProductViewResponse>> increaseViewCount(
+            @PathVariable Long productId) {
+        long viewCount = productViewService.incrementAndGetTotal(productId);
+        return ResponseEntity.ok(ApiResponse.ok(new ProductViewResponse(productId, viewCount)));
     }
 
     // 3-3. 상품 등록 (인플루언서 전용)

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
@@ -46,6 +46,7 @@ public class ProductResponse {
         private ConditionCode condition;
         private CategoryCode categoryCode;
         private Boolean isSoldOut;
+        private Long viewCount; // DB 확정값 (Redis 미반영분은 view 엔드포인트 응답에서 합산)
         private List<ImageDto> images;
         private ZonedDateTime createdAt;
 
@@ -64,6 +65,7 @@ public class ProductResponse {
                     .condition(product.getConditionCode())
                     .categoryCode(product.getCategoryCode())
                     .isSoldOut(product.getIsSoldout())
+                    .viewCount(product.getViewCount())
                     .images(imageDtos)
                     .createdAt(product.getCreatedAt())
                     .build();

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductViewResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductViewResponse.java
@@ -1,0 +1,13 @@
+package com.myfave.api.domain.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 상품 조회수 증가 응답 — DB 확정값 + Redis 미반영 증분 합산한 최신 총합
+@Getter
+@AllArgsConstructor
+public class ProductViewResponse {
+
+    private Long productId;
+    private Long viewCount;
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -56,6 +56,10 @@ public class Product extends BaseEntity {
     @Column(name = "stock_quantity", nullable = false)
     private Integer stockQuantity = 0;
 
+    // 조회수 — Redis 누적분을 스케줄러가 주기적으로 write-back (고빈도 쓰기 DB 락 회피)
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     private ZonedDateTime deletedAt;
 
     @Builder

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -46,11 +46,15 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     long sumStockQuantityByProductIds(@Param("productIds") List<Long> productIds);
 
     // 조회수 write-back — 누적 delta를 한 번에 더함 (엔티티 미로딩, 행 단위 +)
+    // soft-delete 행 제외 — flush 전 삭제된 상품 누적 방지
     @Modifying
-    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id")
+    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id AND p.deletedAt is null")
     int addViewCount(@Param("id") Long id, @Param("delta") long delta);
 
-    // 조회수 단건 조회 — 엔티티 미로딩 (없으면 null)
-    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id")
+    // 조회수 단건 조회 — 엔티티 미로딩 (없거나 삭제 시 null)
+    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id AND p.deletedAt is null")
     Long findViewCountById(@Param("id") Long id);
+
+    // 활성 상품 존재 여부 — 조회수 증가 전 유령/삭제 상품 차단용
+    boolean existsByProductIdAndDeletedAtIsNull(Long productId);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -43,4 +44,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // myfave.stock.snapshot: 부하테스트 시드 상품(reset.sql 기준 productId 1~10) 재고 합계 Gauge용
     @Query("select coalesce(sum(p.stockQuantity), 0) from Product p where p.productId in :productIds")
     long sumStockQuantityByProductIds(@Param("productIds") List<Long> productIds);
+
+    // 조회수 write-back — 누적 delta를 한 번에 더함 (엔티티 미로딩, 행 단위 +)
+    @Modifying
+    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id")
+    int addViewCount(@Param("id") Long id, @Param("delta") long delta);
+
+    // 조회수 단건 조회 — 엔티티 미로딩 (없으면 null)
+    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id")
+    Long findViewCountById(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/scheduler/ProductViewCountScheduler.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/scheduler/ProductViewCountScheduler.java
@@ -1,0 +1,80 @@
+package com.myfave.api.domain.product.scheduler;
+
+import com.myfave.api.domain.product.service.ProductViewService;
+import com.myfave.api.domain.product.service.ProductViewWriteBackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 상품 조회수 write-back 스케줄러 — 주기적으로 Redis 누적분을 DB에 반영
+ * 흐름: dirty set 순회 → 각 키 누적값(delta) 수집 → DB 일괄 반영(커밋) → 커밋 후 Redis 차감
+ * 전체 SCAN 없이 dirty set만 순회해 처리 비용을 최소화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductViewCountScheduler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductViewWriteBackService writeBackService;
+
+    @Scheduled(fixedDelayString = "${product.view.write-back-delay-ms:30000}")
+    public void flush() {
+        Set<Object> members = redisTemplate.opsForSet().members(ProductViewService.DIRTY_SET_KEY);
+        if (members == null || members.isEmpty()) {
+            return;
+        }
+
+        // 1) dirty 멤버별 누적 delta 수집 (delta<=0이거나 손상 멤버는 정리하고 스킵)
+        Map<Long, Long> deltas = new HashMap<>();
+        for (Object raw : members) {
+            String member = raw.toString();
+            long delta = readDelta(member);
+            if (delta <= 0) {
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, member);
+                continue;
+            }
+            try {
+                deltas.put(Long.parseLong(member), delta);
+            } catch (NumberFormatException e) {
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, member);
+            }
+        }
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        // 2) DB 일괄 반영 (커밋). 실패 시 Redis 미차감 → 다음 주기에 재시도 (유실 없음)
+        writeBackService.applyAll(deltas);
+
+        // 3) 커밋 성공 후 Redis 차감. 차감 사이 새로 들어온 조회분은 보존됨
+        deltas.forEach((id, delta) -> {
+            String key = ProductViewService.COUNTER_KEY_PREFIX + id;
+            Long remaining = redisTemplate.opsForValue().decrement(key, delta);
+            if (remaining == null || remaining <= 0) {
+                redisTemplate.delete(key);
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, String.valueOf(id));
+            }
+        });
+        log.debug("[product-view-writeback] {}건 DB 반영", deltas.size());
+    }
+
+    private long readDelta(String member) {
+        Object value = redisTemplate.opsForValue().get(ProductViewService.COUNTER_KEY_PREFIX + member);
+        if (value == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -2,8 +2,11 @@ package com.myfave.api.domain.product.service;
 
 import com.myfave.api.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 /**
  * 상품 조회수 카운터 — 조회 시점에 Redis에만 누적 (쓰기 DB 미접근, 락 없음)
@@ -16,17 +19,33 @@ public class ProductViewService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final ProductRepository productRepository;
+    private final ProductViewWriteBackService writeBackService;
+
+    // redis(권장) | db(부하테스트 비교군: 조회마다 DB 직접 +1, 락 경합)
+    @Value("${product.view.counter-mode:redis}")
+    private String counterMode;
 
     // counter:* 키엔 TTL 없음 — cache:*(만료 O)와 네임스페이스 분리
     public static final String COUNTER_KEY_PREFIX = "counter:view:product:";
     // write-back 대상 키 집합 — 스케줄러가 전체 SCAN 없이 이 set만 순회
     public static final String DIRTY_SET_KEY = "counter:view:product:dirty";
 
-    // 조회수 증가 후 최신 총합 반환 — Redis INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
+    // 조회수 증가 후 최신 총합 반환 — 모드에 따라 Redis 누적 / DB 직접 +1
     public long incrementAndGetTotal(Long productId) {
+        if ("db".equalsIgnoreCase(counterMode)) {
+            return incrementInDb(productId);
+        }
+        // redis 모드: INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
         long pending = increment(productId);
         Long dbCount = productRepository.findViewCountById(productId);
         return (dbCount == null ? 0L : dbCount) + pending;
+    }
+
+    // 비교군 — 조회마다 DB 행에 직접 +1 (동시성 시 락 경합 발생). write-back 우회
+    private long incrementInDb(Long productId) {
+        writeBackService.applyAll(Map.of(productId, 1L));
+        Long dbCount = productRepository.findViewCountById(productId);
+        return dbCount == null ? 0L : dbCount;
     }
 
     // Redis 증분 한 줄 — dirty set에 productId 표시

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -1,6 +1,8 @@
 package com.myfave.api.domain.product.service;
 
 import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -32,6 +34,10 @@ public class ProductViewService {
 
     // 조회수 증가 후 최신 총합 반환 — 모드에 따라 Redis 누적 / DB 직접 +1
     public long incrementAndGetTotal(Long productId) {
+        // 유령/삭제 상품 차단 — Redis 쓰레기 키·write-back 0건 유실 방지(404 계약)
+        if (!productRepository.existsByProductIdAndDeletedAtIsNull(productId)) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
         if ("db".equalsIgnoreCase(counterMode)) {
             return incrementInDb(productId);
         }

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -1,0 +1,38 @@
+package com.myfave.api.domain.product.service;
+
+import com.myfave.api.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 상품 조회수 카운터 — 조회 시점에 Redis에만 누적 (쓰기 DB 미접근, 락 없음)
+ * 실제 DB 반영은 ProductViewCountScheduler가 주기적으로 write-back
+ * 조회수는 1~2개 틀려도 무방한 고빈도 쓰기라 정확성 대신 속도 선택
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductViewService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductRepository productRepository;
+
+    // counter:* 키엔 TTL 없음 — cache:*(만료 O)와 네임스페이스 분리
+    public static final String COUNTER_KEY_PREFIX = "counter:view:product:";
+    // write-back 대상 키 집합 — 스케줄러가 전체 SCAN 없이 이 set만 순회
+    public static final String DIRTY_SET_KEY = "counter:view:product:dirty";
+
+    // 조회수 증가 후 최신 총합 반환 — Redis INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
+    public long incrementAndGetTotal(Long productId) {
+        long pending = increment(productId);
+        Long dbCount = productRepository.findViewCountById(productId);
+        return (dbCount == null ? 0L : dbCount) + pending;
+    }
+
+    // Redis 증분 한 줄 — dirty set에 productId 표시
+    public long increment(Long productId) {
+        Long count = redisTemplate.opsForValue().increment(COUNTER_KEY_PREFIX + productId);
+        redisTemplate.opsForSet().add(DIRTY_SET_KEY, String.valueOf(productId));
+        return count == null ? 0L : count;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewWriteBackService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewWriteBackService.java
@@ -1,0 +1,26 @@
+package com.myfave.api.domain.product.service;
+
+import com.myfave.api.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * 상품 조회수 write-back DB 반영 — 누적 증분들을 한 트랜잭션으로 DB에 더함
+ * 스케줄러와 분리한 이유: "DB 커밋 성공 후 Redis 차감" 순서를 보장하기 위함
+ * (이 메서드가 정상 반환=커밋 완료 후에야 스케줄러가 Redis를 차감)
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductViewWriteBackService {
+
+    private final ProductRepository productRepository;
+
+    // key: productId, value: 누적 delta
+    @Transactional
+    public void applyAll(Map<Long, Long> deltas) {
+        deltas.forEach((id, delta) -> productRepository.addViewCount(id, delta));
+    }
+}

--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig {
                                 "/chat-room/preview",
                                 "/chat-room/messages"
                         ).permitAll()
+                        // 상품 조회수 증가는 비로그인 포함 모두 허용 (Redis 누적, 인증 불필요)
+                        .requestMatchers(HttpMethod.POST, "/products/*/view").permitAll()
                         .anyRequest().authenticated()  // 그 외 모든 요청은 JWT 인증 필수
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,12 @@ app:
 influencer:
   user-id: 1
 
+# 상품 조회수 카운터
+product:
+  view:
+    counter-mode: redis        # redis | db (부하테스트 비교군: db=조회 시 DB 직접 +1, 락 경합 유발)
+    write-back-delay-ms: 30000 # redis 누적분을 DB로 반영하는 스케줄러 주기(ms)
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-must-be-at-least-256-bits-long-here}

--- a/backend/src/main/resources/db/migration/V6__add_product_view_count.sql
+++ b/backend/src/main/resources/db/migration/V6__add_product_view_count.sql
@@ -1,0 +1,4 @@
+-- 상품 조회수 카운터 컬럼 — Redis write-back 대상
+-- 주의: Flyway 미동작(기록용). 운영(prod, ddl-auto=none)은 수동 psql 적용 필요
+-- DEFAULT 있는 컬럼 추가는 PostgreSQL에서 즉시·무중단
+ALTER TABLE products ADD COLUMN IF NOT EXISTS view_count BIGINT NOT NULL DEFAULT 0;

--- a/frontend/src/features/products/api.ts
+++ b/frontend/src/features/products/api.ts
@@ -1,5 +1,9 @@
 import { apiClient } from '@/shared/api/axios'
-import type { ProductListApiResponse, ProductDetailApiResponse } from './types'
+import type {
+  ProductListApiResponse,
+  ProductDetailApiResponse,
+  ProductViewApiResponse,
+} from './types'
 
 export const productsApi = {
   getList: async (page = 0, size = 50): Promise<ProductListApiResponse> => {
@@ -10,6 +14,11 @@ export const productsApi = {
   },
   getDetail: async (id: number): Promise<ProductDetailApiResponse> => {
     const res = await apiClient.get<{ data: ProductDetailApiResponse }>(`/products/${id}`)
+    return res.data.data
+  },
+  // 조회수 증가 (Redis 누적) — 최신 총합 반환
+  increaseView: async (id: number): Promise<ProductViewApiResponse> => {
+    const res = await apiClient.post<{ data: ProductViewApiResponse }>(`/products/${id}/view`)
     return res.data.data
   },
 }

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 
 import { productsApi } from './api'
 import { getProductImages, getProductThumbnail } from './imageMap'
@@ -78,6 +78,7 @@ function toProductDetail(item: ProductDetailApiResponse): ProductDetail {
     images,
     isSoldOut: item.isSoldOut,
     conditionLabel: mapConditionLabel(item.condition),
+    viewCount: item.viewCount ?? 0,
     features: item.description
       ? [{ title: '상품 설명', description: item.description }]
       : [],
@@ -116,5 +117,12 @@ export function useProduct(id: number | undefined) {
     queryKey: ['product', id],
     queryFn: () => productsApi.getDetail(id!).then(toProductDetail),
     enabled: id != null,
+  })
+}
+
+// 상품 조회 시 조회수 +1 (Redis 누적) — 응답으로 최신 총합을 받음
+export function useIncreaseProductView() {
+  return useMutation({
+    mutationFn: (id: number) => productsApi.increaseView(id),
   })
 }

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { productsApi } from './api'
 import { getProductImages, getProductThumbnail } from './imageMap'
@@ -122,7 +122,12 @@ export function useProduct(id: number | undefined) {
 
 // 상품 조회 시 조회수 +1 (Redis 누적) — 응답으로 최신 총합을 받음
 export function useIncreaseProductView() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => productsApi.increaseView(id),
+    // 성공 후 상세 캐시 무효화 — viewData를 직접 안 쓰는 소비자도 최신 viewCount 반영
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['product', id] })
+    },
   })
 }

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -25,6 +25,8 @@ export interface ProductDetail {
   isSoldOut: boolean
   // 상품 상태 등급 라벨 (예: 'S급'). 백엔드 condition(S_GRADE 등)을 변환한 값. 없으면 빈 문자열.
   conditionLabel: string
+  // 조회수 (DB 확정값). 조회 시 view 호출 응답으로 최신값 갱신
+  viewCount: number
 }
 
 export interface InfluencerPick extends Product {
@@ -53,6 +55,13 @@ export interface ProductDetailApiResponse {
   isSoldOut: boolean
   images: { imageId: number; imageUrl: string; sortOrder: number; isMain: boolean }[]
   createdAt: string
+  viewCount: number
+}
+
+// 조회수 증가 응답 — DB 확정값 + Redis 미반영분 합산한 최신 총합
+export interface ProductViewApiResponse {
+  productId: number
+  viewCount: number
 }
 
 export interface ProductListApiResponse {

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -1,10 +1,10 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useIsAuthenticated } from '@/features/auth/hooks'
 import { useCartStore } from '@/features/cart/store'
 import { useCheckoutStore } from '@/features/payments/store'
-import { useProduct } from '@/features/products/hooks'
+import { useIncreaseProductView, useProduct } from '@/features/products/hooks'
 import { Modal } from '@/shared/components/Modal'
 import { PopUp } from '@/shared/components/PopUp'
 import { SmartImage } from '@/shared/components/SmartImage'
@@ -14,6 +14,12 @@ export function ProductDetailPage() {
   const navigate = useNavigate()
   const productId = Number(id) || 1
   const { data: product, isLoading } = useProduct(productId)
+  const { mutate: increaseView, data: viewData } = useIncreaseProductView()
+
+  // 상세 진입 시 조회수 +1 (productId 바뀔 때마다). view 응답이 가장 최신값
+  useEffect(() => {
+    increaseView(productId)
+  }, [productId, increaseView])
   const addCartItem = useCartStore((s) => s.addItem)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
   const setOrderType = useCheckoutStore((s) => s.setOrderType)
@@ -166,6 +172,13 @@ export function ProductDetailPage() {
         <div className="space-y-[12px]">
           <h1 className="font-noto text-[15px] font-normal leading-[24px] text-[#322927] tracking-tight">{product.title}</h1>
           <p className="font-noto text-[12px] font-normal leading-[18px] text-chat-font">{product.subtitle}</p>
+          <p className="flex items-center gap-[4px] font-noto text-[11px] font-normal leading-[16px] text-chat-font">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            조회 {(viewData?.viewCount ?? product.viewCount ?? 0).toLocaleString()}
+          </p>
           <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>
             {product.conditionLabel && (

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -15,11 +15,15 @@ export function ProductDetailPage() {
   const productId = Number(id) || 1
   const { data: product, isLoading } = useProduct(productId)
   const { mutate: increaseView, data: viewData } = useIncreaseProductView()
+  const viewedRef = useRef<number | null>(null)
 
-  // 상세 진입 시 조회수 +1 (productId 바뀔 때마다). view 응답이 가장 최신값
+  // 상세 로드 성공 후 상품당 한 번만 조회수 +1 — 없는 상품/조회 실패엔 집계 안 보냄
   useEffect(() => {
+    if (product?.id !== productId) return
+    if (viewedRef.current === productId) return
+    viewedRef.current = productId
     increaseView(productId)
-  }, [productId, increaseView])
+  }, [product, productId, increaseView])
   const addCartItem = useCartStore((s) => s.addItem)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
   const setOrderType = useCheckoutStore((s) => s.setOrderType)
@@ -177,7 +181,7 @@ export function ProductDetailPage() {
               <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
               <circle cx="12" cy="12" r="3" />
             </svg>
-            조회 {(viewData?.viewCount ?? product.viewCount ?? 0).toLocaleString()}
+            조회 {(viewData?.productId === productId ? viewData.viewCount : product.viewCount ?? 0).toLocaleString()}
           </p>
           <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>


### PR DESCRIPTION
## 📌 관련 이슈
Closes #이슈번호

## 작업 내용

없던 상품 조회수 기능을 신규 구축
조회는 Redis에만 누적(락 없음)하고 스케줄러가 주기적으로 DB에 일괄 반영(write-back)하는 방식으로 고빈도 쓰기를 DB 락 경합 없이 처리
상품 상세 페이지에 조회수를 표시하고, 부하테스트 비교용 토글과 k6 시나리오를 함께 추가

## 🔍 변경 사항

- [x] 기능 추가 (상품 조회수 카운터, view 엔드포인트, write-back 스케줄러, 상세 페이지 표시)
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 추가 / 수정 (k6 시나리오 C)
- [ ] 문서 수정
- [x] 기타 (설명: V6 기록용 DDL, counter-mode 토글, 프론트 연동)

## 💡 구현 방법 / 주요 변경 포인트

- 왜 Redis: 조회수는 1~2개 틀려도 무방한 초고빈도 쓰기. 인기 상품 한 row에 동시 +1이 몰리면 DB 락으로 줄을 서 조회까지 느려짐 → 틀려도 되는 값은 락을 빼서 속도를 얻음(인스타·유튜브 방식).
- 조회 트리거: POST /products/{productId}/view 신설(공개, permitAll). INCR counter:view:product:{id} + dirty set(SADD counter:view:product:dirty)에 표시만. 쓰기 시 DB 미접근.
- write-back 흐름 (3분리: 레포 bulk update / write-back 서비스 / 스케줄러):
  a. @Scheduled(기본 30초)로 깨어남
  b. dirty set만 순회(전체 SCAN 없음)해 각 키 누적 delta 수집
  c. ProductViewWriteBackService가 UPDATE products SET view_count = view_count + :delta를 한 트랜잭션으로 커밋
  d. 커밋 성공 후 Redis에서 delta만큼 DECRBY(그 사이 들어온 조회분 보존), 0 이하면 키·dirty 정리
  - "DB 커밋 → Redis 차감" 순서를 강제하려고 트랜잭션 계층을 스케줄러에서 분리. 실패 시 미차감 → 다음 주기 재시도(유실 없음).
- 키 네임스페이스: counter:*(TTL 없음, 유실 시 마지막 flush 이후만 손실).
- 응답/표시: 상품 상세 응답(ProductResponse.Detail)에 viewCount(DB 확정값) 추가. view 엔드포인트는 DB+Redis 미반영분 합산한 최신값 반환. 프론트 ProductDetailPage가 진입 시 view를 호출하고 그 응답값을 표시.
- 비교군 토글: product.view.counter-mode: redis|db. db는 조회마다 DB 직접 +1(락 경합) — 부하테스트 before/after 대비용.

## ✅ 테스트 방법

1. 환경 설정: docker-compose up -d(PostgreSQL, Redis), cd backend. 로컬은 ddl-auto: update라 view_count 컬럼 자동 생성. (운영은 V6 수동 psql 선적용)
2. 실행 방법: 백엔드 ./gradlew bootRun / 프론트 cd frontend && yarn build && yarn dev
3. 확인 사항:
  - 상품 상세(/product/1) 진입 → POST /products/1/view 호출되고 화면에 "조회 N" 표시, 재진입 시 증가 확인
  - Redis counter:view:product:1 증가 → 스케줄러 주기(30초) 후 DB products.view_count 반영 + Redis 차감 확인
  - product.view.counter-mode=db로 재기동 시 즉시 DB 반영되는지 확인
  - k6 시나리오 C를 counter-mode redis/db 각각으로 돌려 TPS·p99 비교

## ⚠️ 리뷰어에게 전달 사항

- view 엔드포인트 응답의 DB read: 최신 총합 반환을 위해 조회당 SELECT 1회가 있습니다. 쓰기 락이 아닌 non-locking read라 카운터 경합 회피 목적은 유지됩니다.
- 운영 배포 순서: Flyway 미동작이라 prod는 V6 수동 psql 적용(DDL 먼저) → 코드 배포 순서 필수. counter:* 키엔 TTL 미설정(의도).
- 프론트 검증: 로컬 node_modules 미설치로 tsc 미실행 — Vercel 프리뷰 빌드(yarn build=tsc+vite)에서 타입체크됩니다. 빨간 체크 시 알려주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 상품 상세 페이지에 조회수가 표시됩니다.
  * 상품 상세 진입 시 조회수가 자동으로 반영됩니다.
  * 상품 조회수 증가를 위한 공개 API가 추가되었습니다.

* **Bug Fixes**
  * 조회수는 최신 반영값과 함께 표시되도록 개선되었습니다.
  * 대규모 조회 요청에서도 조회수 집계가 안정적으로 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->