### PR TITLE
Feat/product like

### DIFF
--- a/backend/load-test/k6/scenarios/scenario-c-view-counter.js
+++ b/backend/load-test/k6/scenarios/scenario-c-view-counter.js
@@ -1,0 +1,56 @@
+// 시나리오 C — 상품 조회수 카운터 집중 (조회수 고도화 측정용)
+// 인기 상품 1개에 조회(POST view)를 몰아넣어 카운터 쓰기 경합을 유발.
+// 목적: counter-mode=db(조회마다 DB 직접 +1, 행 락 경합) vs redis(INCR, 락 없음) 대비.
+// 운영법: 백엔드 product.view.counter-mode 를 db / redis 로 바꿔가며 2회 측정 후 비교.
+// 지표: TPS(iterations), p99 latency. (DB write 횟수·락 대기는 서버 Prometheus/Hibernate 통계로 관측)
+
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import http from 'k6/http';
+
+import { post, BASE_URL } from '../lib/http.js';
+import { tokens } from '../lib/pool.js';
+
+http.setResponseCallback(http.expectedStatuses({ min: 200, max: 299 }));
+
+// 경합을 보려고 단일 인기 상품에 집중 (모든 VU가 같은 row/key를 때림)
+const HOT_PRODUCT_ID = __ENV.HOT_PRODUCT_ID || '1';
+
+export const options = {
+  scenarios: {
+    view_counter: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 100 },
+        { duration: '10s', target: 1000 },
+        { duration: '3m', target: 1000 },
+        { duration: '30s', target: 0 },
+      ],
+      gracefulRampDown: '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(99)<1000'],
+  },
+};
+
+const viewErrors = new Counter('view_counter_errors');
+
+export function setup() {
+  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}, 토큰 풀=${tokens.length}`);
+}
+
+export default function () {
+  // view 엔드포인트는 공개(permitAll)지만 헤더 일관성 위해 토큰 부착
+  const accessToken = tokens[(__VU - 1) % tokens.length].accessToken;
+
+  // 단일 인기 상품에 조회수 몰빵 — 카운터 쓰기 경합 집중
+  const res = post(`/products/${HOT_PRODUCT_ID}/view`, accessToken, {});
+
+  const ok = check(res, { 'status < 500': (r) => r.status < 500 });
+  if (!ok) viewErrors.add(1);
+
+  sleep(Math.random() * 0.3);
+}

--- a/backend/load-test/k6/scenarios/scenario-c-view-counter.js
+++ b/backend/load-test/k6/scenarios/scenario-c-view-counter.js
@@ -8,8 +8,7 @@ import { check, sleep } from 'k6';
 import { Counter } from 'k6/metrics';
 import http from 'k6/http';
 
-import { post, BASE_URL } from '../lib/http.js';
-import { tokens } from '../lib/pool.js';
+import { BASE_URL } from '../lib/http.js';
 
 http.setResponseCallback(http.expectedStatuses({ min: 200, max: 299 }));
 
@@ -39,15 +38,17 @@ export const options = {
 const viewErrors = new Counter('view_counter_errors');
 
 export function setup() {
-  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}, 토큰 풀=${tokens.length}`);
+  console.log(`[scenario-C] BASE_URL=${BASE_URL}, 핫상품=product/${HOT_PRODUCT_ID}`);
 }
 
 export default function () {
-  // view 엔드포인트는 공개(permitAll)지만 헤더 일관성 위해 토큰 부착
-  const accessToken = tokens[(__VU - 1) % tokens.length].accessToken;
-
+  // view 엔드포인트는 공개(permitAll) — 인증 시드(tokens.json)와 분리해 무인증 POST
   // 단일 인기 상품에 조회수 몰빵 — 카운터 쓰기 경합 집중
-  const res = post(`/products/${HOT_PRODUCT_ID}/view`, accessToken, {});
+  const res = http.post(
+    `${BASE_URL}/products/${HOT_PRODUCT_ID}/view`,
+    null,
+    { headers: { 'Content-Type': 'application/json' } },
+  );
 
   const ok = check(res, { 'status < 500': (r) => r.status < 500 });
   if (!ok) viewErrors.add(1);

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -4,8 +4,10 @@ import com.myfave.api.domain.product.dto.request.ProductRequest;
 import com.myfave.api.domain.product.dto.request.ProductUpdateRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
+import com.myfave.api.domain.product.dto.response.ProductViewResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.service.ProductService;
+import com.myfave.api.domain.product.service.ProductViewService;
 import com.myfave.api.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,6 +30,7 @@ import java.util.Map;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductViewService productViewService;
 
     // 3-1. 상품 목록 조회
     @GetMapping
@@ -46,6 +49,14 @@ public class ProductController {
             @PathVariable Long productId) {
         ProductResponse.Detail response = productService.getProduct(productId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 3-7. 상품 조회수 증가 (Redis 누적, 비로그인 포함 공개)
+    @PostMapping("/{productId}/view")
+    public ResponseEntity<ApiResponse<ProductViewResponse>> increaseViewCount(
+            @PathVariable Long productId) {
+        long viewCount = productViewService.incrementAndGetTotal(productId);
+        return ResponseEntity.ok(ApiResponse.ok(new ProductViewResponse(productId, viewCount)));
     }
 
     // 3-3. 상품 등록 (인플루언서 전용)

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -46,11 +46,12 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    // 3-2. 상품 상세 조회
+    // 3-2. 상품 상세 조회 (공개 — 로그인 시 userId로 liked 계산, 비로그인 null)
     @GetMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductResponse.Detail>> getProduct(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long productId) {
-        ProductResponse.Detail response = productService.getProduct(productId);
+        ProductResponse.Detail response = productService.getProduct(productId, userId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/controller/ProductController.java
@@ -4,8 +4,10 @@ import com.myfave.api.domain.product.dto.request.ProductRequest;
 import com.myfave.api.domain.product.dto.request.ProductUpdateRequest;
 import com.myfave.api.domain.product.dto.response.ProductListResponse;
 import com.myfave.api.domain.product.dto.response.ProductResponse;
+import com.myfave.api.domain.product.dto.response.ProductLikeResponse;
 import com.myfave.api.domain.product.dto.response.ProductViewResponse;
 import com.myfave.api.domain.product.entity.CategoryCode;
+import com.myfave.api.domain.product.service.ProductLikeService;
 import com.myfave.api.domain.product.service.ProductService;
 import com.myfave.api.domain.product.service.ProductViewService;
 import com.myfave.api.global.common.ApiResponse;
@@ -31,6 +33,7 @@ public class ProductController {
 
     private final ProductService productService;
     private final ProductViewService productViewService;
+    private final ProductLikeService productLikeService;
 
     // 3-1. 상품 목록 조회
     @GetMapping
@@ -57,6 +60,15 @@ public class ProductController {
             @PathVariable Long productId) {
         long viewCount = productViewService.incrementAndGetTotal(productId);
         return ResponseEntity.ok(ApiResponse.ok(new ProductViewResponse(productId, viewCount)));
+    }
+
+    // 3-8. 상품 좋아요 토글 (로그인 필수) — 누르면 추가, 이미 눌렀으면 취소
+    @PostMapping("/{productId}/like")
+    public ResponseEntity<ApiResponse<ProductLikeResponse>> toggleLike(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long productId) {
+        ProductLikeResponse response = productLikeService.toggle(userId, productId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     // 3-3. 상품 등록 (인플루언서 전용)

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductLikeResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductLikeResponse.java
@@ -1,0 +1,14 @@
+package com.myfave.api.domain.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 좋아요 토글 응답 — 현재 유저의 좋아요 상태(liked)와 상품 총 좋아요 수
+@Getter
+@AllArgsConstructor
+public class ProductLikeResponse {
+
+    private Long productId;
+    private boolean liked;
+    private Long likeCount;
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
@@ -46,6 +46,7 @@ public class ProductResponse {
         private ConditionCode condition;
         private CategoryCode categoryCode;
         private Boolean isSoldOut;
+        private Long viewCount; // DB 확정값 (Redis 미반영분은 view 엔드포인트 응답에서 합산)
         private List<ImageDto> images;
         private ZonedDateTime createdAt;
 
@@ -64,6 +65,7 @@ public class ProductResponse {
                     .condition(product.getConditionCode())
                     .categoryCode(product.getCategoryCode())
                     .isSoldOut(product.getIsSoldout())
+                    .viewCount(product.getViewCount())
                     .images(imageDtos)
                     .createdAt(product.getCreatedAt())
                     .build();

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductResponse.java
@@ -21,6 +21,7 @@ public class ProductResponse {
     private String thumbnailUrl;
     private Boolean isSoldOut;
     private CategoryCode categoryCode;
+    private Long likeCount; // 좋아요순 정렬·표시용
 
     public static ProductResponse from(Product product, String thumbnailUrl) {
         return new ProductResponse(
@@ -29,7 +30,8 @@ public class ProductResponse {
                 product.getPrice(),
                 thumbnailUrl,
                 product.getIsSoldout(),
-                product.getCategoryCode()
+                product.getCategoryCode(),
+                product.getLikeCount()
         );
     }
 
@@ -47,10 +49,12 @@ public class ProductResponse {
         private CategoryCode categoryCode;
         private Boolean isSoldOut;
         private Long viewCount; // DB 확정값 (Redis 미반영분은 view 엔드포인트 응답에서 합산)
+        private Long likeCount; // 상품 총 좋아요 수
+        private Boolean liked;  // 현재 로그인 유저의 좋아요 여부 (비로그인=false)
         private List<ImageDto> images;
         private ZonedDateTime createdAt;
 
-        public static Detail from(Product product, List<ProductImage> images) {
+        public static Detail from(Product product, List<ProductImage> images, boolean liked) {
             List<ImageDto> imageDtos = images.stream()
                     .map(ImageDto::from)
                     .toList();
@@ -66,6 +70,8 @@ public class ProductResponse {
                     .categoryCode(product.getCategoryCode())
                     .isSoldOut(product.getIsSoldout())
                     .viewCount(product.getViewCount())
+                    .likeCount(product.getLikeCount())
+                    .liked(liked)
                     .images(imageDtos)
                     .createdAt(product.getCreatedAt())
                     .build();

--- a/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductViewResponse.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/dto/response/ProductViewResponse.java
@@ -1,0 +1,13 @@
+package com.myfave.api.domain.product.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 상품 조회수 증가 응답 — DB 확정값 + Redis 미반영 증분 합산한 최신 총합
+@Getter
+@AllArgsConstructor
+public class ProductViewResponse {
+
+    private Long productId;
+    private Long viewCount;
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -56,6 +56,10 @@ public class Product extends BaseEntity {
     @Column(name = "stock_quantity", nullable = false)
     private Integer stockQuantity = 0;
 
+    // 조회수 — Redis 누적분을 스케줄러가 주기적으로 write-back (고빈도 쓰기 DB 락 회피)
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     private ZonedDateTime deletedAt;
 
     @Builder

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/Product.java
@@ -60,6 +60,10 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
+    // 좋아요 수 — 비정규화 카운터 (표시·정렬용). 토글 트랜잭션에서 동기 갱신
+    @Column(nullable = false)
+    private Long likeCount = 0L;
+
     private ZonedDateTime deletedAt;
 
     @Builder

--- a/backend/src/main/java/com/myfave/api/domain/product/entity/ProductLike.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/entity/ProductLike.java
@@ -1,0 +1,50 @@
+package com.myfave.api.domain.product.entity;
+
+import com.myfave.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 상품 좋아요 — User↔Product 조인 (회원당 상품 1번, unique 제약으로 멱등 보장)
+ * 좋아요는 정확성·중복방지가 필요해 Redis 누적이 아닌 DB 동기 반영 (조회수와 대비)
+ */
+@Entity
+@Table(name = "product_likes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_product_like_user_product",
+                columnNames = {"user_id", "product_id"}))
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_like_id")
+    private Long productLikeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private ZonedDateTime createdAt;
+
+    @Builder
+    private ProductLike(User user, Product product) {
+        this.user = user;
+        this.product = product;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductLikeRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductLikeRepository.java
@@ -1,0 +1,13 @@
+package com.myfave.api.domain.product.repository;
+
+import com.myfave.api.domain.product.entity.ProductLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+
+    // 현재 유저가 해당 상품을 좋아요 했는지 (상세 liked 표시용)
+    boolean existsByUser_UserIdAndProduct_ProductId(Long userId, Long productId);
+
+    // 좋아요 취소 — 삭제된 행 수 반환 (0이면 좋아요 없던 상태)
+    long deleteByUser_UserIdAndProduct_ProductId(Long userId, Long productId);
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -55,6 +55,15 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id AND p.deletedAt is null")
     Long findViewCountById(@Param("id") Long id);
 
-    // 활성 상품 존재 여부 — 조회수 증가 전 유령/삭제 상품 차단용
+    // 활성 상품 존재 여부 — 조회수 증가·좋아요 토글 전 유령/삭제 상품 차단용
     boolean existsByProductIdAndDeletedAtIsNull(Long productId);
+
+    // 좋아요 수 비정규화 카운터 갱신 — 토글 트랜잭션에서 원자적 +1/-1
+    @Modifying
+    @Query("UPDATE Product p SET p.likeCount = p.likeCount + :delta WHERE p.productId = :id")
+    int addLikeCount(@Param("id") Long id, @Param("delta") long delta);
+
+    // 좋아요 수 단건 조회 — 엔티티 미로딩 (없으면 null)
+    @Query("SELECT p.likeCount FROM Product p WHERE p.productId = :id")
+    Long findLikeCountById(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -46,11 +46,15 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     long sumStockQuantityByProductIds(@Param("productIds") List<Long> productIds);
 
     // 조회수 write-back — 누적 delta를 한 번에 더함 (엔티티 미로딩, 행 단위 +)
+    // soft-delete 행 제외 — flush 전 삭제된 상품 누적 방지
     @Modifying
-    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id")
+    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id AND p.deletedAt is null")
     int addViewCount(@Param("id") Long id, @Param("delta") long delta);
 
-    // 조회수 단건 조회 — 엔티티 미로딩 (없으면 null)
-    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id")
+    // 조회수 단건 조회 — 엔티티 미로딩 (없거나 삭제 시 null)
+    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id AND p.deletedAt is null")
     Long findViewCountById(@Param("id") Long id);
+
+    // 활성 상품 존재 여부 — 조회수 증가 전 유령/삭제 상품 차단용
+    boolean existsByProductIdAndDeletedAtIsNull(Long productId);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/repository/ProductRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -43,4 +44,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // myfave.stock.snapshot: 부하테스트 시드 상품(reset.sql 기준 productId 1~10) 재고 합계 Gauge용
     @Query("select coalesce(sum(p.stockQuantity), 0) from Product p where p.productId in :productIds")
     long sumStockQuantityByProductIds(@Param("productIds") List<Long> productIds);
+
+    // 조회수 write-back — 누적 delta를 한 번에 더함 (엔티티 미로딩, 행 단위 +)
+    @Modifying
+    @Query("UPDATE Product p SET p.viewCount = p.viewCount + :delta WHERE p.productId = :id")
+    int addViewCount(@Param("id") Long id, @Param("delta") long delta);
+
+    // 조회수 단건 조회 — 엔티티 미로딩 (없으면 null)
+    @Query("SELECT p.viewCount FROM Product p WHERE p.productId = :id")
+    Long findViewCountById(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/myfave/api/domain/product/scheduler/ProductViewCountScheduler.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/scheduler/ProductViewCountScheduler.java
@@ -1,0 +1,80 @@
+package com.myfave.api.domain.product.scheduler;
+
+import com.myfave.api.domain.product.service.ProductViewService;
+import com.myfave.api.domain.product.service.ProductViewWriteBackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 상품 조회수 write-back 스케줄러 — 주기적으로 Redis 누적분을 DB에 반영
+ * 흐름: dirty set 순회 → 각 키 누적값(delta) 수집 → DB 일괄 반영(커밋) → 커밋 후 Redis 차감
+ * 전체 SCAN 없이 dirty set만 순회해 처리 비용을 최소화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductViewCountScheduler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductViewWriteBackService writeBackService;
+
+    @Scheduled(fixedDelayString = "${product.view.write-back-delay-ms:30000}")
+    public void flush() {
+        Set<Object> members = redisTemplate.opsForSet().members(ProductViewService.DIRTY_SET_KEY);
+        if (members == null || members.isEmpty()) {
+            return;
+        }
+
+        // 1) dirty 멤버별 누적 delta 수집 (delta<=0이거나 손상 멤버는 정리하고 스킵)
+        Map<Long, Long> deltas = new HashMap<>();
+        for (Object raw : members) {
+            String member = raw.toString();
+            long delta = readDelta(member);
+            if (delta <= 0) {
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, member);
+                continue;
+            }
+            try {
+                deltas.put(Long.parseLong(member), delta);
+            } catch (NumberFormatException e) {
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, member);
+            }
+        }
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        // 2) DB 일괄 반영 (커밋). 실패 시 Redis 미차감 → 다음 주기에 재시도 (유실 없음)
+        writeBackService.applyAll(deltas);
+
+        // 3) 커밋 성공 후 Redis 차감. 차감 사이 새로 들어온 조회분은 보존됨
+        deltas.forEach((id, delta) -> {
+            String key = ProductViewService.COUNTER_KEY_PREFIX + id;
+            Long remaining = redisTemplate.opsForValue().decrement(key, delta);
+            if (remaining == null || remaining <= 0) {
+                redisTemplate.delete(key);
+                redisTemplate.opsForSet().remove(ProductViewService.DIRTY_SET_KEY, String.valueOf(id));
+            }
+        });
+        log.debug("[product-view-writeback] {}건 DB 반영", deltas.size());
+    }
+
+    private long readDelta(String member) {
+        Object value = redisTemplate.opsForValue().get(ProductViewService.COUNTER_KEY_PREFIX + member);
+        if (value == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductLikeService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductLikeService.java
@@ -1,0 +1,62 @@
+package com.myfave.api.domain.product.service;
+
+import com.myfave.api.domain.product.dto.response.ProductLikeResponse;
+import com.myfave.api.domain.product.entity.ProductLike;
+import com.myfave.api.domain.product.repository.ProductLikeRepository;
+import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.domain.user.repository.UserRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 상품 좋아요 — 토글(누르면 추가/이미 눌렀으면 취소)
+ * 정확성·중복방지가 필요해 DB 동기 반영 + unique 제약으로 회원당 1회 보장 (조회수와 대비)
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductLikeService {
+
+    private final ProductLikeRepository productLikeRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ProductLikeResponse toggle(Long userId, Long productId) {
+        // 상품 존재 검증 (soft-delete 제외) — 없는 상품에 좋아요 시 404
+        if (!productRepository.existsByProductIdAndDeletedAtIsNull(productId)) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 삭제 시도 → 삭제된 행이 있으면 "좋아요 취소", 없으면 "좋아요 추가" (별도 exists 조회 없이 경합 안전)
+        long deleted = productLikeRepository.deleteByUser_UserIdAndProduct_ProductId(userId, productId);
+        boolean liked;
+        if (deleted > 0) {
+            productRepository.addLikeCount(productId, -deleted);
+            liked = false;
+        } else {
+            liked = addLike(userId, productId);
+        }
+
+        Long likeCount = productRepository.findLikeCountById(productId);
+        return new ProductLikeResponse(productId, liked, likeCount == null ? 0L : likeCount);
+    }
+
+    // 좋아요 추가 — 동시 중복 insert는 unique 제약 위반으로 잡아 멱등 처리
+    private boolean addLike(Long userId, Long productId) {
+        try {
+            ProductLike like = ProductLike.builder()
+                    .user(userRepository.getReferenceById(userId))
+                    .product(productRepository.getReferenceById(productId))
+                    .build();
+            productLikeRepository.saveAndFlush(like); // flush로 unique 위반 즉시 감지
+            productRepository.addLikeCount(productId, 1);
+        } catch (DataIntegrityViolationException e) {
+            // 이미 좋아요된 상태 (동시 클릭 등) — 카운트 중복 증가 방지
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductService.java
@@ -8,6 +8,7 @@ import com.myfave.api.domain.product.entity.CategoryCode;
 import com.myfave.api.domain.product.entity.Product;
 import com.myfave.api.domain.product.entity.ProductImage;
 import com.myfave.api.domain.product.repository.ProductImageRepository;
+import com.myfave.api.domain.product.repository.ProductLikeRepository;
 import com.myfave.api.domain.product.repository.ProductRepository;
 import com.myfave.api.domain.user.entity.User;
 import com.myfave.api.domain.user.repository.UserRepository;
@@ -33,6 +34,7 @@ public class ProductService {
 
     private final ProductRepository productRepository; //상품 데이터
     private final ProductImageRepository productImageRepository; //이미지 데이터
+    private final ProductLikeRepository productLikeRepository; //좋아요 데이터
     private final UserRepository userRepository;
     private final S3UploadService s3UploadService;
 
@@ -64,15 +66,18 @@ public class ProductService {
         return ProductListResponse.from(responsePage);
     }
 
-    // 3-2. 상품 상세 조회
-    public ProductResponse.Detail getProduct(Long productId) {
+    // 3-2. 상품 상세 조회 (userId: 비로그인 시 null → liked=false)
+    public ProductResponse.Detail getProduct(Long productId, Long userId) {
         // ID기반으로 찾고 못찾으면 404 에러
         Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         List<ProductImage> images = productImageRepository.findByProductOrderBySortOrderAsc(product);
 
-        return ProductResponse.Detail.from(product, images);
+        boolean liked = userId != null
+                && productLikeRepository.existsByUser_UserIdAndProduct_ProductId(userId, productId);
+
+        return ProductResponse.Detail.from(product, images, liked);
     }
     // 3-3. 상품 등록 (인플루언서 전용)
     @Transactional //쓰기 가능

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -2,8 +2,11 @@ package com.myfave.api.domain.product.service;
 
 import com.myfave.api.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 /**
  * 상품 조회수 카운터 — 조회 시점에 Redis에만 누적 (쓰기 DB 미접근, 락 없음)
@@ -16,17 +19,33 @@ public class ProductViewService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final ProductRepository productRepository;
+    private final ProductViewWriteBackService writeBackService;
+
+    // redis(권장) | db(부하테스트 비교군: 조회마다 DB 직접 +1, 락 경합)
+    @Value("${product.view.counter-mode:redis}")
+    private String counterMode;
 
     // counter:* 키엔 TTL 없음 — cache:*(만료 O)와 네임스페이스 분리
     public static final String COUNTER_KEY_PREFIX = "counter:view:product:";
     // write-back 대상 키 집합 — 스케줄러가 전체 SCAN 없이 이 set만 순회
     public static final String DIRTY_SET_KEY = "counter:view:product:dirty";
 
-    // 조회수 증가 후 최신 총합 반환 — Redis INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
+    // 조회수 증가 후 최신 총합 반환 — 모드에 따라 Redis 누적 / DB 직접 +1
     public long incrementAndGetTotal(Long productId) {
+        if ("db".equalsIgnoreCase(counterMode)) {
+            return incrementInDb(productId);
+        }
+        // redis 모드: INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
         long pending = increment(productId);
         Long dbCount = productRepository.findViewCountById(productId);
         return (dbCount == null ? 0L : dbCount) + pending;
+    }
+
+    // 비교군 — 조회마다 DB 행에 직접 +1 (동시성 시 락 경합 발생). write-back 우회
+    private long incrementInDb(Long productId) {
+        writeBackService.applyAll(Map.of(productId, 1L));
+        Long dbCount = productRepository.findViewCountById(productId);
+        return dbCount == null ? 0L : dbCount;
     }
 
     // Redis 증분 한 줄 — dirty set에 productId 표시

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -1,6 +1,8 @@
 package com.myfave.api.domain.product.service;
 
 import com.myfave.api.domain.product.repository.ProductRepository;
+import com.myfave.api.global.error.CustomException;
+import com.myfave.api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -32,6 +34,10 @@ public class ProductViewService {
 
     // 조회수 증가 후 최신 총합 반환 — 모드에 따라 Redis 누적 / DB 직접 +1
     public long incrementAndGetTotal(Long productId) {
+        // 유령/삭제 상품 차단 — Redis 쓰레기 키·write-back 0건 유실 방지(404 계약)
+        if (!productRepository.existsByProductIdAndDeletedAtIsNull(productId)) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
         if ("db".equalsIgnoreCase(counterMode)) {
             return incrementInDb(productId);
         }

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewService.java
@@ -1,0 +1,38 @@
+package com.myfave.api.domain.product.service;
+
+import com.myfave.api.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 상품 조회수 카운터 — 조회 시점에 Redis에만 누적 (쓰기 DB 미접근, 락 없음)
+ * 실제 DB 반영은 ProductViewCountScheduler가 주기적으로 write-back
+ * 조회수는 1~2개 틀려도 무방한 고빈도 쓰기라 정확성 대신 속도 선택
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductViewService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductRepository productRepository;
+
+    // counter:* 키엔 TTL 없음 — cache:*(만료 O)와 네임스페이스 분리
+    public static final String COUNTER_KEY_PREFIX = "counter:view:product:";
+    // write-back 대상 키 집합 — 스케줄러가 전체 SCAN 없이 이 set만 순회
+    public static final String DIRTY_SET_KEY = "counter:view:product:dirty";
+
+    // 조회수 증가 후 최신 총합 반환 — Redis INCR(쓰기 락 없음) + DB 확정값 read(non-locking)
+    public long incrementAndGetTotal(Long productId) {
+        long pending = increment(productId);
+        Long dbCount = productRepository.findViewCountById(productId);
+        return (dbCount == null ? 0L : dbCount) + pending;
+    }
+
+    // Redis 증분 한 줄 — dirty set에 productId 표시
+    public long increment(Long productId) {
+        Long count = redisTemplate.opsForValue().increment(COUNTER_KEY_PREFIX + productId);
+        redisTemplate.opsForSet().add(DIRTY_SET_KEY, String.valueOf(productId));
+        return count == null ? 0L : count;
+    }
+}

--- a/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewWriteBackService.java
+++ b/backend/src/main/java/com/myfave/api/domain/product/service/ProductViewWriteBackService.java
@@ -1,0 +1,26 @@
+package com.myfave.api.domain.product.service;
+
+import com.myfave.api.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * 상품 조회수 write-back DB 반영 — 누적 증분들을 한 트랜잭션으로 DB에 더함
+ * 스케줄러와 분리한 이유: "DB 커밋 성공 후 Redis 차감" 순서를 보장하기 위함
+ * (이 메서드가 정상 반환=커밋 완료 후에야 스케줄러가 Redis를 차감)
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductViewWriteBackService {
+
+    private final ProductRepository productRepository;
+
+    // key: productId, value: 누적 delta
+    @Transactional
+    public void applyAll(Map<Long, Long> deltas) {
+        deltas.forEach((id, delta) -> productRepository.addViewCount(id, delta));
+    }
+}

--- a/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/myfave/api/global/config/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig {
                                 "/chat-room/preview",
                                 "/chat-room/messages"
                         ).permitAll()
+                        // 상품 조회수 증가는 비로그인 포함 모두 허용 (Redis 누적, 인증 불필요)
+                        .requestMatchers(HttpMethod.POST, "/products/*/view").permitAll()
                         .anyRequest().authenticated()  // 그 외 모든 요청은 JWT 인증 필수
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,12 @@ app:
 influencer:
   user-id: 1
 
+# 상품 조회수 카운터
+product:
+  view:
+    counter-mode: redis        # redis | db (부하테스트 비교군: db=조회 시 DB 직접 +1, 락 경합 유발)
+    write-back-delay-ms: 30000 # redis 누적분을 DB로 반영하는 스케줄러 주기(ms)
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-must-be-at-least-256-bits-long-here}

--- a/backend/src/main/resources/db/migration/V6__add_product_view_count.sql
+++ b/backend/src/main/resources/db/migration/V6__add_product_view_count.sql
@@ -1,0 +1,4 @@
+-- 상품 조회수 카운터 컬럼 — Redis write-back 대상
+-- 주의: Flyway 미동작(기록용). 운영(prod, ddl-auto=none)은 수동 psql 적용 필요
+-- DEFAULT 있는 컬럼 추가는 PostgreSQL에서 즉시·무중단
+ALTER TABLE products ADD COLUMN IF NOT EXISTS view_count BIGINT NOT NULL DEFAULT 0;

--- a/backend/src/main/resources/db/migration/V7__add_product_likes.sql
+++ b/backend/src/main/resources/db/migration/V7__add_product_likes.sql
@@ -1,0 +1,16 @@
+-- 상품 좋아요 — 좋아요 수 비정규화 컬럼 + 좋아요 조인 테이블
+-- 주의: Flyway 미동작(기록용). 운영(prod, ddl-auto=none)은 수동 psql 적용 필요
+ALTER TABLE products ADD COLUMN IF NOT EXISTS like_count BIGINT NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS product_likes (
+    product_like_id BIGSERIAL PRIMARY KEY,
+    user_id    BIGINT NOT NULL REFERENCES users(user_id),
+    product_id BIGINT NOT NULL REFERENCES products(product_id),
+    created_at TIMESTAMPTZ,
+    CONSTRAINT uq_product_like_user_product UNIQUE (user_id, product_id)
+);
+
+-- 좋아요 토글 시 회원-상품 중복 체크 조회용
+CREATE INDEX IF NOT EXISTS idx_product_likes_product ON product_likes(product_id);
+-- 좋아요순 정렬(ORDER BY like_count DESC)용
+CREATE INDEX IF NOT EXISTS idx_products_like_count ON products(like_count DESC);

--- a/frontend/src/features/products/api.ts
+++ b/frontend/src/features/products/api.ts
@@ -1,5 +1,9 @@
 import { apiClient } from '@/shared/api/axios'
-import type { ProductListApiResponse, ProductDetailApiResponse } from './types'
+import type {
+  ProductListApiResponse,
+  ProductDetailApiResponse,
+  ProductViewApiResponse,
+} from './types'
 
 export const productsApi = {
   getList: async (page = 0, size = 50): Promise<ProductListApiResponse> => {
@@ -10,6 +14,11 @@ export const productsApi = {
   },
   getDetail: async (id: number): Promise<ProductDetailApiResponse> => {
     const res = await apiClient.get<{ data: ProductDetailApiResponse }>(`/products/${id}`)
+    return res.data.data
+  },
+  // 조회수 증가 (Redis 누적) — 최신 총합 반환
+  increaseView: async (id: number): Promise<ProductViewApiResponse> => {
+    const res = await apiClient.post<{ data: ProductViewApiResponse }>(`/products/${id}/view`)
     return res.data.data
   },
 }

--- a/frontend/src/features/products/api.ts
+++ b/frontend/src/features/products/api.ts
@@ -3,6 +3,7 @@ import type {
   ProductListApiResponse,
   ProductDetailApiResponse,
   ProductViewApiResponse,
+  ProductLikeApiResponse,
 } from './types'
 
 export const productsApi = {
@@ -19,6 +20,11 @@ export const productsApi = {
   // 조회수 증가 (Redis 누적) — 최신 총합 반환
   increaseView: async (id: number): Promise<ProductViewApiResponse> => {
     const res = await apiClient.post<{ data: ProductViewApiResponse }>(`/products/${id}/view`)
+    return res.data.data
+  },
+  // 좋아요 토글 (로그인 필수) — 토글 후 상태·총합 반환
+  toggleLike: async (id: number): Promise<ProductLikeApiResponse> => {
+    const res = await apiClient.post<{ data: ProductLikeApiResponse }>(`/products/${id}/like`)
     return res.data.data
   },
 }

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 
 import { productsApi } from './api'
 import { getProductImages, getProductThumbnail } from './imageMap'
@@ -78,6 +78,7 @@ function toProductDetail(item: ProductDetailApiResponse): ProductDetail {
     images,
     isSoldOut: item.isSoldOut,
     conditionLabel: mapConditionLabel(item.condition),
+    viewCount: item.viewCount ?? 0,
     features: item.description
       ? [{ title: '상품 설명', description: item.description }]
       : [],
@@ -116,5 +117,12 @@ export function useProduct(id: number | undefined) {
     queryKey: ['product', id],
     queryFn: () => productsApi.getDetail(id!).then(toProductDetail),
     enabled: id != null,
+  })
+}
+
+// 상품 조회 시 조회수 +1 (Redis 누적) — 응답으로 최신 총합을 받음
+export function useIncreaseProductView() {
+  return useMutation({
+    mutationFn: (id: number) => productsApi.increaseView(id),
   })
 }

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { productsApi } from './api'
 import { getProductImages, getProductThumbnail } from './imageMap'
@@ -122,7 +122,12 @@ export function useProduct(id: number | undefined) {
 
 // 상품 조회 시 조회수 +1 (Redis 누적) — 응답으로 최신 총합을 받음
 export function useIncreaseProductView() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => productsApi.increaseView(id),
+    // 성공 후 상세 캐시 무효화 — viewData를 직접 안 쓰는 소비자도 최신 viewCount 반영
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['product', id] })
+    },
   })
 }

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -48,6 +48,7 @@ function toProduct(item: ProductApiItem): Product {
     price: item.price.toLocaleString() + '원',
     category: mapCategory(item.categoryCode),
     isSoldOut: item.isSoldOut,
+    likeCount: item.likeCount ?? 0,
   }
 }
 

--- a/frontend/src/features/products/hooks.ts
+++ b/frontend/src/features/products/hooks.ts
@@ -79,6 +79,8 @@ function toProductDetail(item: ProductDetailApiResponse): ProductDetail {
     isSoldOut: item.isSoldOut,
     conditionLabel: mapConditionLabel(item.condition),
     viewCount: item.viewCount ?? 0,
+    likeCount: item.likeCount ?? 0,
+    liked: item.liked ?? false,
     features: item.description
       ? [{ title: '상품 설명', description: item.description }]
       : [],
@@ -128,6 +130,40 @@ export function useIncreaseProductView() {
     // 성공 후 상세 캐시 무효화 — viewData를 직접 안 쓰는 소비자도 최신 viewCount 반영
     onSuccess: (_data, id) => {
       queryClient.invalidateQueries({ queryKey: ['product', id] })
+    },
+  })
+}
+
+// 좋아요 토글 — 낙관적 업데이트(즉시 하트·숫자 반영) 후 서버 응답으로 보정
+export function useToggleProductLike(productId: number) {
+  const queryClient = useQueryClient()
+  const key = ['product', productId]
+  return useMutation({
+    mutationFn: () => productsApi.toggleLike(productId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: key })
+      const prev = queryClient.getQueryData<ProductDetail>(key)
+      if (prev) {
+        queryClient.setQueryData<ProductDetail>(key, {
+          ...prev,
+          liked: !prev.liked,
+          likeCount: prev.likeCount + (prev.liked ? -1 : 1),
+        })
+      }
+      return { prev }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) queryClient.setQueryData(key, context.prev)
+    },
+    onSuccess: (res) => {
+      const cur = queryClient.getQueryData<ProductDetail>(key)
+      if (cur) {
+        queryClient.setQueryData<ProductDetail>(key, {
+          ...cur,
+          liked: res.liked,
+          likeCount: res.likeCount,
+        })
+      }
     },
   })
 }

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -27,6 +27,10 @@ export interface ProductDetail {
   conditionLabel: string
   // 조회수 (DB 확정값). 조회 시 view 호출 응답으로 최신값 갱신
   viewCount: number
+  // 좋아요 수
+  likeCount: number
+  // 현재 로그인 유저가 좋아요 눌렀는지 (비로그인=false)
+  liked: boolean
 }
 
 export interface InfluencerPick extends Product {
@@ -56,12 +60,21 @@ export interface ProductDetailApiResponse {
   images: { imageId: number; imageUrl: string; sortOrder: number; isMain: boolean }[]
   createdAt: string
   viewCount: number
+  likeCount: number
+  liked: boolean
 }
 
 // 조회수 증가 응답 — DB 확정값 + Redis 미반영분 합산한 최신 총합
 export interface ProductViewApiResponse {
   productId: number
   viewCount: number
+}
+
+// 좋아요 토글 응답 — 현재 유저 좋아요 상태 + 총 좋아요 수
+export interface ProductLikeApiResponse {
+  productId: number
+  liked: boolean
+  likeCount: number
 }
 
 export interface ProductListApiResponse {

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -25,6 +25,8 @@ export interface ProductDetail {
   isSoldOut: boolean
   // 상품 상태 등급 라벨 (예: 'S급'). 백엔드 condition(S_GRADE 등)을 변환한 값. 없으면 빈 문자열.
   conditionLabel: string
+  // 조회수 (DB 확정값). 조회 시 view 호출 응답으로 최신값 갱신
+  viewCount: number
 }
 
 export interface InfluencerPick extends Product {
@@ -53,6 +55,13 @@ export interface ProductDetailApiResponse {
   isSoldOut: boolean
   images: { imageId: number; imageUrl: string; sortOrder: number; isMain: boolean }[]
   createdAt: string
+  viewCount: number
+}
+
+// 조회수 증가 응답 — DB 확정값 + Redis 미반영분 합산한 최신 총합
+export interface ProductViewApiResponse {
+  productId: number
+  viewCount: number
 }
 
 export interface ProductListApiResponse {

--- a/frontend/src/features/products/types.ts
+++ b/frontend/src/features/products/types.ts
@@ -12,6 +12,7 @@ export interface Product {
   price: string
   category: ProductCategory
   isSoldOut?: boolean
+  likeCount: number
 }
 
 export interface ProductDetail {
@@ -45,6 +46,7 @@ export interface ProductApiItem {
   thumbnailUrl: string | null
   isSoldOut: boolean
   categoryCode: string | null
+  likeCount: number
 }
 
 export interface ProductDetailApiResponse {

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -1,10 +1,10 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useIsAuthenticated } from '@/features/auth/hooks'
 import { useCartStore } from '@/features/cart/store'
 import { useCheckoutStore } from '@/features/payments/store'
-import { useProduct } from '@/features/products/hooks'
+import { useIncreaseProductView, useProduct } from '@/features/products/hooks'
 import { Modal } from '@/shared/components/Modal'
 import { PopUp } from '@/shared/components/PopUp'
 import { SmartImage } from '@/shared/components/SmartImage'
@@ -14,6 +14,12 @@ export function ProductDetailPage() {
   const navigate = useNavigate()
   const productId = Number(id) || 1
   const { data: product, isLoading } = useProduct(productId)
+  const { mutate: increaseView, data: viewData } = useIncreaseProductView()
+
+  // 상세 진입 시 조회수 +1 (productId 바뀔 때마다). view 응답이 가장 최신값
+  useEffect(() => {
+    increaseView(productId)
+  }, [productId, increaseView])
   const addCartItem = useCartStore((s) => s.addItem)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
   const setOrderType = useCheckoutStore((s) => s.setOrderType)
@@ -166,6 +172,13 @@ export function ProductDetailPage() {
         <div className="space-y-[12px]">
           <h1 className="font-noto text-[15px] font-normal leading-[24px] text-[#322927] tracking-tight">{product.title}</h1>
           <p className="font-noto text-[12px] font-normal leading-[18px] text-chat-font">{product.subtitle}</p>
+          <p className="flex items-center gap-[4px] font-noto text-[11px] font-normal leading-[16px] text-chat-font">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+            조회 {(viewData?.viewCount ?? product.viewCount ?? 0).toLocaleString()}
+          </p>
           <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>
             {product.conditionLabel && (

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { useIsAuthenticated } from '@/features/auth/hooks'
 import { useCartStore } from '@/features/cart/store'
 import { useCheckoutStore } from '@/features/payments/store'
-import { useIncreaseProductView, useProduct } from '@/features/products/hooks'
+import { useIncreaseProductView, useProduct, useToggleProductLike } from '@/features/products/hooks'
 import { Modal } from '@/shared/components/Modal'
 import { PopUp } from '@/shared/components/PopUp'
 import { SmartImage } from '@/shared/components/SmartImage'
@@ -16,6 +16,7 @@ export function ProductDetailPage() {
   const { data: product, isLoading } = useProduct(productId)
   const { mutate: increaseView, data: viewData } = useIncreaseProductView()
   const viewedRef = useRef<number | null>(null)
+  const { mutate: toggleLike } = useToggleProductLike(productId)
 
   // 상세 로드 성공 후 상품당 한 번만 조회수 +1 — 없는 상품/조회 실패엔 집계 안 보냄
   useEffect(() => {
@@ -24,6 +25,15 @@ export function ProductDetailPage() {
     viewedRef.current = productId
     increaseView(productId)
   }, [product, productId, increaseView])
+
+  // 좋아요 클릭 — 비로그인은 로그인 유도, 로그인은 토글(낙관적 업데이트)
+  const handleLikeClick = () => {
+    if (!isAuthenticated) {
+      setIsAuthModalOpen(true)
+      return
+    }
+    toggleLike()
+  }
   const addCartItem = useCartStore((s) => s.addItem)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
   const setOrderType = useCheckoutStore((s) => s.setOrderType)
@@ -176,13 +186,28 @@ export function ProductDetailPage() {
         <div className="space-y-[12px]">
           <h1 className="font-noto text-[15px] font-normal leading-[24px] text-[#322927] tracking-tight">{product.title}</h1>
           <p className="font-noto text-[12px] font-normal leading-[18px] text-chat-font">{product.subtitle}</p>
-          <p className="flex items-center gap-[4px] font-noto text-[11px] font-normal leading-[16px] text-chat-font">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
-              <circle cx="12" cy="12" r="3" />
-            </svg>
-            조회 {(viewData?.productId === productId ? viewData.viewCount : product.viewCount ?? 0).toLocaleString()}
-          </p>
+          <div className="flex items-center justify-between pt-[2px]">
+            <span className="flex items-center gap-[4px] font-noto text-[11px] font-normal leading-[16px] text-chat-font">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+              조회 {(viewData?.productId === productId ? viewData.viewCount : product.viewCount ?? 0).toLocaleString()}
+            </span>
+            {/* 좋아요 토글 — 빈 하트 ↔ 채운 하트(팀컬러 point). 비로그인 클릭 시 로그인 유도 */}
+            <button
+              type="button"
+              onClick={handleLikeClick}
+              aria-pressed={product.liked}
+              aria-label={product.liked ? '좋아요 취소' : '좋아요'}
+              className={`flex items-center gap-[4px] font-noto text-[12px] font-medium leading-[16px] transition-colors active:scale-95 ${product.liked ? 'text-point' : 'text-chat-font'}`}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill={product.liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+              </svg>
+              {(product.likeCount ?? 0).toLocaleString()}
+            </button>
+          </div>
           <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>
             {product.conditionLabel && (

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -15,11 +15,15 @@ export function ProductDetailPage() {
   const productId = Number(id) || 1
   const { data: product, isLoading } = useProduct(productId)
   const { mutate: increaseView, data: viewData } = useIncreaseProductView()
+  const viewedRef = useRef<number | null>(null)
 
-  // 상세 진입 시 조회수 +1 (productId 바뀔 때마다). view 응답이 가장 최신값
+  // 상세 로드 성공 후 상품당 한 번만 조회수 +1 — 없는 상품/조회 실패엔 집계 안 보냄
   useEffect(() => {
+    if (product?.id !== productId) return
+    if (viewedRef.current === productId) return
+    viewedRef.current = productId
     increaseView(productId)
-  }, [productId, increaseView])
+  }, [product, productId, increaseView])
   const addCartItem = useCartStore((s) => s.addItem)
   const setCheckoutItems = useCheckoutStore((s) => s.setItems)
   const setOrderType = useCheckoutStore((s) => s.setOrderType)
@@ -177,7 +181,7 @@ export function ProductDetailPage() {
               <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
               <circle cx="12" cy="12" r="3" />
             </svg>
-            조회 {(viewData?.viewCount ?? product.viewCount ?? 0).toLocaleString()}
+            조회 {(viewData?.productId === productId ? viewData.viewCount : product.viewCount ?? 0).toLocaleString()}
           </p>
           <div className="flex items-center gap-[8px] pt-[4px]">
             <span className="font-noto text-[20px] font-medium leading-[30px] text-[#322927]">{product.price}</span>

--- a/frontend/src/pages/ProductListPage.tsx
+++ b/frontend/src/pages/ProductListPage.tsx
@@ -14,13 +14,28 @@ const CATEGORIES = [
 export function ProductListPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedCategory = searchParams.get('category') ?? 'all'
+  // 정렬: 기본 latest(최신=서버 기본순), likes(좋아요순). 카테고리 필터처럼 클라이언트에서 처리.
+  const sort = searchParams.get('sort') === 'likes' ? 'likes' : 'latest'
   // 로딩/에러 상태를 빈 배열로 숨기면 장애가 "상품 0개" 로 묻혀 사용자에게 혼란을 줌 (CR M12).
   const { data: products = [], isLoading, isError } = useProducts()
 
-  const filteredProducts =
+  const categoryFiltered =
     selectedCategory === 'all'
       ? products
       : products.filter((p) => p.category === selectedCategory)
+
+  const filteredProducts =
+    sort === 'likes'
+      ? [...categoryFiltered].sort((a, b) => b.likeCount - a.likeCount)
+      : categoryFiltered
+
+  // category는 유지하면서 sort만 갱신 (빈 값이면 파라미터 제거)
+  const updateSort = (next: 'latest' | 'likes') => {
+    const params = new URLSearchParams(searchParams)
+    if (next === 'likes') params.set('sort', 'likes')
+    else params.delete('sort')
+    setSearchParams(params)
+  }
 
   return (
     <div className="flex-1 bg-white">
@@ -31,11 +46,13 @@ export function ProductListPage() {
             {CATEGORIES.map((cat) => (
               <button
                 key={cat.value}
-                onClick={() =>
-                  cat.value === 'all'
-                    ? setSearchParams({})
-                    : setSearchParams({ category: cat.value })
-                }
+                onClick={() => {
+                  // sort 파라미터는 유지하면서 category만 변경
+                  const params = new URLSearchParams(searchParams)
+                  if (cat.value === 'all') params.delete('category')
+                  else params.set('category', cat.value)
+                  setSearchParams(params)
+                }}
                 className={`h-full font-noto text-[12px] font-medium transition-all ${
                   selectedCategory === cat.value
                     ? 'text-dark-text border-b-[1.096px] border-dark-text'
@@ -49,11 +66,27 @@ export function ProductListPage() {
         </div>
       </div>
 
-      {/* 2. Product count - 카테고리 탭 바로 아래 위치 (간격 축소) */}
-      <div className="mx-auto max-w-[376.04px] bg-white h-[40px] px-[19.99px] flex items-center">
+      {/* 2. Product count + 정렬 토글 - 카테고리 탭 바로 아래 */}
+      <div className="mx-auto max-w-[376.04px] bg-white h-[40px] px-[19.99px] flex items-center justify-between">
         <p className="font-noto text-[12px] font-normal text-dark-text">
           상품 <span className="font-medium text-black">{filteredProducts.length}</span>개
         </p>
+        <div className="flex items-center gap-[12px]">
+          {([
+            { label: '최신순', value: 'latest' },
+            { label: '좋아요순', value: 'likes' },
+          ] as const).map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => updateSort(opt.value)}
+              className={`font-noto text-[12px] transition-colors ${
+                sort === opt.value ? 'font-medium text-point' : 'text-muted-text hover:text-dark-text/70'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* 3. Products grid - 하단 상품 카드 리스트 (각진 모서리 반영) */}

--- a/frontend/src/pages/ProductListPage.tsx
+++ b/frontend/src/pages/ProductListPage.tsx
@@ -14,7 +14,7 @@ const CATEGORIES = [
 export function ProductListPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedCategory = searchParams.get('category') ?? 'all'
-  // 정렬: 기본 latest(최신=서버 기본순), likes(좋아요순). 카테고리 필터처럼 클라이언트에서 처리.
+  // 정렬: 기본 latest(최신=서버 기본순), likes(인기순=좋아요 수). 카테고리 필터처럼 클라이언트에서 처리.
   const sort = searchParams.get('sort') === 'likes' ? 'likes' : 'latest'
   // 로딩/에러 상태를 빈 배열로 숨기면 장애가 "상품 0개" 로 묻혀 사용자에게 혼란을 줌 (CR M12).
   const { data: products = [], isLoading, isError } = useProducts()
@@ -74,7 +74,7 @@ export function ProductListPage() {
         <div className="flex items-center gap-[12px]">
           {([
             { label: '최신순', value: 'latest' },
-            { label: '좋아요순', value: 'likes' },
+            { label: '인기순', value: 'likes' },
           ] as const).map((opt) => (
             <button
               key={opt.value}

--- a/frontend/src/pages/ProductListPage.tsx
+++ b/frontend/src/pages/ProductListPage.tsx
@@ -19,6 +19,11 @@ export function ProductListPage() {
   // 로딩/에러 상태를 빈 배열로 숨기면 장애가 "상품 0개" 로 묻혀 사용자에게 혼란을 줌 (CR M12).
   const { data: products = [], isLoading, isError } = useProducts()
 
+  // [SCALE/MSA NOTE] 현재 카테고리 필터·정렬 모두 클라이언트 처리 (전체 50개 로드 → JS 가공)
+  // 상품 수 급증/MSA 전환 시 서버 주도로 이관 필요. 백엔드는 이미 지원: GET /products?categoryCode=&sort=likeCount,desc&page=&size=
+  // 주의 ① "정렬만" 서버로 옮기면 버그 — 서버가 전체 인기순 상위 N개 준 뒤 클라가 카테고리 필터하면 누락 발생.
+  //      카테고리·정렬·페이지네이션을 한 묶음으로 서버 이관해야 함
+  // 주의 ② 목록용 hook은 useProducts(=메인 useInfluencerPicks와 ['products'] 캐시 공유, 전체 로드 의존)와 분리 필요
   const categoryFiltered =
     selectedCategory === 'all'
       ? products


### PR DESCRIPTION
## 📌 관련 이슈
Closes #이슈번호

## 📝 작업 내용
상품 좋아요(찜) 기능을 신규 구축
회원당 상품 1회 좋아요(토글), 상품 상세에 하트 UI·좋아요 수 표시, 상품 목록 좋아요순 정렬
조회수와 달리 정확성이 필요해 DB 동기 반영으로 구현

## 🔍 변경 사항

- [x] 기능 추가 (좋아요 토글 API, 하트 UI, 좋아요순 정렬)
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가 / 수정
- [ ] 문서 수정
- [x] 기타 (V7 기록용 DDL, 프론트 연동)

## 💡 구현 방법 / 주요 변경 포인트

- 왜 동기(DB)인가: 좋아요는 조회수와 정반대. 사용자 의도적 클릭(저빈도) + 정확성·회원당 1회·정렬 필요 → Redis 누적 대신 DB 트랜잭션 즉시 반영. (조회수=Redis write-back과 대비되는 설계 선택)
- 엔티티/스키마: ProductLike(User↔Product, @UniqueConstraint(user_id, product_id)로 멱등 보장), products.like_count 비정규화 컬럼(표시·정렬용). V7__add_product_likes.sql 기록용.
- 토글 API POST /products/{id}/like(로그인 필수): 삭제 시도 → 삭제행 있으면 "취소", 없으면 "추가"(별도 exists 조회 없이 경합 안전). like_count는 원자적 UPDATE ... +:delta. 동시 중복 insert는 unique 제약으로 잡아 멱등 처리. 응답 {liked, likeCount}.
- 조회 응답: 상세(ProductResponse.Detail)에 likeCount + liked(현재 유저 기준, 비로그인=false — 공개 GET에 nullable @AuthenticationPrincipal). 목록(ProductResponse)에 likeCount.
- 정렬: 백엔드 resolveSort가 sort=likeCount,desc를 그대로 지원(추가 코드 없음). 인덱스 idx_products_like_count 추가. 프론트 목록은 기존 구조(클라 필터)와 일관되게 클라이언트 정렬.
- 프론트: 상품 상세 하트 토글(빈↔채움, 팀컬러 point), 낙관적 업데이트(즉시 반영 후 서버 응답 보정), 비로그인 클릭 시 기존 로그인 모달. 목록 "좋아요순" 정렬 토글(category·sort 파라미터 동시 유지).

## ✅ 테스트 방법

1. docker-compose up -d, 백엔드 ./gradlew bootRun(로컬 ddl-auto=update라 컬럼·테이블 자동) / 프론트 yarn build && yarn dev
2. 확인:
  - 상품 상세에서 하트 클릭 → 채워짐+카운트+1, 재클릭 → 빈하트+카운트-1 (같은 회원 멱등)
  - 비로그인 상태로 하트 클릭 → 로그인 모달
  - 상품 목록 "좋아요순" → 정렬 변경, 카테고리 바꿔도 정렬 유지
  - 다른 회원으로 같은 상품 좋아요 → 카운트 누적

## ⚠️ 리뷰어에게 전달 사항

- 운영 배포 순서: Flyway 미동작 → prod는 V7 수동 psql 적용(DDL 먼저) 후 코드 배포. 팀원 로컬/loadtest는 ddl-auto=update라 자동.
- 목록 정렬은 현재 클라이언트 정렬(카탈로그 소규모). 추후 서버 페이지네이션 전환 시 sort=likeCount,desc(이미 API 지원)로 바꾸면 됨.
