### PR TITLE
chore: [CLAUDE.md] 코드에서 유추 가능한 내용 및 깨진 참조 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,3 @@
 - **Commit Style**: `.gitmessage.txt` 템플릿을 준수하고, "Why"에 집중하여 작성하세요.
 - **No Co-Authored-By**: 커밋 메시지에 `Co-Authored-By: Codex` 트레일러를 절대 추가하지 마세요.
 - **Safe Push**: Push 전 반드시 `git pull`을 수행하여 충돌을 로컬에서 해결하세요.
-
-## 4. Key Global Commands
-- **Infrastructure**: `docker-compose up -d` (PostgreSQL, Redis 실행)
-- **Check Status**: `git status && git branch`
-- **Full Build**: `cd backend && ./gradlew build`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,3 @@
 - **Commit Style**: `.gitmessage.txt` 템플릿을 준수하고, "Why"에 집중하여 작성하세요.
 - **No Co-Authored-By**: 커밋 메시지에 `Co-Authored-By: Claude` 트레일러를 절대 추가하지 마세요.
 - **Safe Push**: Push 전 반드시 `git pull`을 수행하여 충돌을 로컬에서 해결하세요.
-
-## 4. Key Global Commands
-- **Infrastructure**: `docker-compose up -d` (PostgreSQL, Redis 실행)
-- **Check Status**: `git status && git branch`
-- **Full Build**: `cd backend && ./gradlew build`

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,7 +1,7 @@
 # MyFave Backend Guide (Token-Optimized)
 
 ## 1. Critical Implementation Standards (Strict)
-- **Timezone**: DB `TIMESTAMPTZ`, Java `OffsetDateTime` 필수 (`LocalDateTime` 금지).
+- **Timezone**: DB `TIMESTAMPTZ`. 영속 엔티티·도메인 필드는 `ZonedDateTime` (`BaseEntity`가 기준). 외부 API 응답 파싱 DTO는 `OffsetDateTime` 허용 (shipping의 택배사 연동). `LocalDateTime`은 어느 계층에서도 금지.
 - **Audit**: UPDATE 시 `updated_at` 수동 갱신 (JPA `@PreUpdate` 또는 Service 레이어).
 - **Inheritance**: `CartItem`, `ChatRoom`, `OrderItem`, `ShortForm`, `StyleFeed`는 `BaseEntity`를 상속하지 않음 (`updated_at` 필드 없음).
 - **Format**: 모든 응답은 `global/common/ApiResponse.java` 사용.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,28 +1,23 @@
 # MyFave Backend Guide (Token-Optimized)
 
-## 1. Backend Core Rules
-- **Structure**: Controller-Service-Repository (Domain-driven)
-- **Persistence**: PostgreSQL (JPA/Hibernate)
-- **Validation**: `@Valid` (Request DTO), `ErrorCode` Enum (Business logic)
-
-## 2. Critical Implementation Standards (Strict)
+## 1. Critical Implementation Standards (Strict)
 - **Timezone**: DB `TIMESTAMPTZ`, Java `OffsetDateTime` 필수 (`LocalDateTime` 금지).
 - **Audit**: UPDATE 시 `updated_at` 수동 갱신 (JPA `@PreUpdate` 또는 Service 레이어).
 - **Inheritance**: `CartItem`, `ChatRoom`, `OrderItem`, `ShortForm`, `StyleFeed`는 `BaseEntity`를 상속하지 않음 (`updated_at` 필드 없음).
 - **Format**: 모든 응답은 `global/common/ApiResponse.java` 사용.
 
-## 3. Build & Test Commands
+## 2. Build & Test Commands
 - **Build**: `./gradlew build -x test`
 - **Run**: `./gradlew bootRun`
 - **Test**: `./gradlew test`
 - **Clean**: `./gradlew clean`
 
-## 4. Token Efficiency Strategy
+## 3. Token Efficiency Strategy
 - **File Discovery**: "관련 파일 찾아줘" 대신 `grep_search`를 사용하여 핵심 심볼을 먼저 검색한 뒤 `read_file` 하세요.
 - **Directory Scope**: `domain/{도메인명}` 폴더 내부에서 작업 범위를 좁히세요.
 - **Direct Reference**: `global/error/ErrorCode.java`, `global/common/ApiResponse.java`는 코드 생성 시 빈번하게 참조되므로 위치를 기억하세요.
 
-## 5. Advanced Pattern: Saga (Payments)
+## 4. Advanced Pattern: Saga (Payments)
 - **Context**: 주문/결제 순환 참조 구조
 - **Pattern**: 결제 실패 시 보상 트랜잭션(주문 상태 복구) 로직을 반드시 포함하세요.
 - **Constraint**: `final_payment_id`는 결제 성공 완료 시점에만 UPDATE 하세요.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -11,7 +11,7 @@
 ## Context
 
 - **프로젝트**: 인플루언서가 팔로워(약 1만 명)를 대상으로 한정 수량 상품을 드롭하는 플리마켓 커머스
-- **백엔드**: Java/Spring Boot, PostgreSQL, Redis. API 명세서는 `/docs/api/MyFave_API_명세서.md` 참고
+- **백엔드**: Java/Spring Boot, PostgreSQL, Redis. API 스펙은 Swagger UI(`/swagger-ui/index.html`)에서 확인
 - **핵심 시나리오**: 오픈 예고 → 오픈 30분 전 채팅방 자동 개설 → 오픈 즉시 재고 5개에 300명 동시 구매
 - **디자인**: Figma 프로토타입 기반 (핑크 팔레트, 모바일 퍼스트)
 
@@ -81,14 +81,6 @@
 - 훅/유틸 파일: `camelCase.ts` (예: `useDebounce.ts`, `formatPrice.ts`)
 - 폴더: `kebab-case` (예: `sale-events/`)
 
-### Import 순서 (ESLint가 강제)
-
-1. 빌트인 (`react`, `react-dom`)
-2. 외부 패키지 (`axios`, `@tanstack/react-query`)
-3. 내부 `@/` alias
-4. 상대경로
-5. 스타일 import는 마지막
-
 ### 커밋 컨벤션
 
 - 예시
@@ -153,64 +145,6 @@ if (error.response?.data?.errorCode === 'PRODUCT_SOLD_OUT') {
 - ❌ 상대경로 지옥 (`../../../`) — `@/` alias 사용
 - ❌ localStorage에 민감정보 저장 (JWT 제외. JWT도 XSS 취약하다는 건 인지)
 - ❌ `<form>` 안에서 `<button>` type 미지정 (기본 submit이라 버그 유발)
-
-## 자주 쓰는 스니펫
-
-### 보호된 라우트 가드
-
-```tsx
-import { Navigate, Outlet } from 'react-router-dom'
-
-export function ProtectedRoute() {
-  const token = localStorage.getItem('accessToken')
-  if (!token) return <Navigate to="/login" replace />
-  return <Outlet />
-}
-```
-
-### 무한스크롤 (상품 목록)
-
-```tsx
-import { useInfiniteQuery } from '@tanstack/react-query'
-
-export function useProductsInfinite(categoryCode: string) {
-  return useInfiniteQuery({
-    queryKey: ['products', { categoryCode }],
-    queryFn: ({ pageParam = 0 }) => productsApi.getList({ categoryCode, page: pageParam }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
-  })
-}
-```
-
-### 카운트다운 타이머 바
-
-```tsx
-import { useEffect, useState } from 'react'
-import { differenceInSeconds } from 'date-fns'
-
-export function CountdownBar({ saleStartAt }: { saleStartAt: string }) {
-  const [remaining, setRemaining] = useState(() =>
-    differenceInSeconds(new Date(saleStartAt), new Date()),
-  )
-
-  useEffect(() => {
-    if (remaining <= 0) return
-    const t = setInterval(() => setRemaining((r) => r - 1), 1000)
-    return () => clearInterval(t)
-  }, [remaining])
-
-  const hh = String(Math.floor(remaining / 3600)).padStart(2, '0')
-  const mm = String(Math.floor((remaining % 3600) / 60)).padStart(2, '0')
-  const ss = String(remaining % 60).padStart(2, '0')
-
-  return (
-    <div className="bg-pink-100 text-pink-700 text-center py-2">
-      마이페이브 판매 시작까지 {hh}:{mm}:{ss}
-    </div>
-  )
-}
-```
 
 ## 응답 포맷 (사용자에게 답할 때)
 


### PR DESCRIPTION
## 📌 관련 이슈
Closes #235

## 📝 작업 내용
세션마다 컨텍스트에 상주하는 CLAUDE.md에서 **코드를 읽으면 그대로 알 수 있는 내용**과 **깨진 참조**를 제거하고, **코드와 어긋난 규칙 1건을 정정**했습니다. 삭제 86줄 / 추가 5줄.

## 🔍 변경 사항
- [x] 문서 수정

## 💡 구현 방법 / 주요 변경 포인트

판단 기준은 하나입니다 — **"세션이 코드를 읽어서 재구성할 수 있는가?"** 가능하면 삭제, 불가능하면 유지.

| 파일 | 삭제 | 근거 |
|---|---|---|
| `CLAUDE.md`, `AGENTS.md` | §4 Key Global Commands (각 5줄) | `docker-compose.yml`이 루트에 있고, `git status` / `./gradlew build`는 표준 호출 |
| `backend/CLAUDE.md` | §1 Backend Core Rules (5줄) | Controller-Service-Repository 구조는 폴더 트리에, PostgreSQL/JPA는 `build.gradle`에 이미 있음 |
| `frontend/CLAUDE.md` | Import 순서 (7줄) | `eslint.config.js`가 기계적으로 강제 — 문서로 중복 기술할 이유 없음 |
| `frontend/CLAUDE.md` | 스니펫 3종 (57줄) | 일반적인 React 패턴. 문서에 고정해두면 실제 코드와 갈라질 위험만 남음 |

**깨진 참조 1건 수정** — `frontend/CLAUDE.md`가 가리키던 `/docs/api/MyFave_API_명세서.md`는 저장소에 없고, `docs/`는 `.gitignore` 대상이라 팀원 로컬에도 없습니다. `springdoc-openapi 2.8.0` + `SwaggerConfig.java`가 이미 붙어 있어 `/swagger-ui/index.html`로 교체했습니다.

**타임존 규약 정정 (커밋 `330bc3b`)** — 아래 별도 항목 참고.

**유지한 것** — 유추 불가능한 내용은 그대로입니다: 커밋 규칙, `Co-Authored-By` 금지, Safe Push, Audit 규약, `BaseEntity` 미상속 목록, Saga 보상 패턴, `./gradlew build -x test`의 `-x test` 플래그, API 응답 계약(`data.data` 벗기기), `errorCode` 분기, 금지 사항 9개, 응답 포맷.

`AGENTS.md`는 `CLAUDE.md`와 2줄만 다른 사실상 복제본이라 같은 삭제를 적용했습니다. 두 파일이 갈라지지 않게 하려면 향후 한쪽을 심볼릭 링크로 두는 것도 방법입니다.

## 🕐 타임존 규약 정정 — 리뷰 포인트

기존 문서는 이렇게 되어 있었습니다:

> **Timezone**: DB `TIMESTAMPTZ`, Java `OffsetDateTime` 필수 (`LocalDateTime` 금지).

실제 코드와 반대입니다. 항상 로드되는 규칙이라 매 세션 잘못된 방향을 지시하고 있었습니다.

| 타입 | 실제 사용 | 성격 |
|---|---|---|
| `ZonedDateTime` | 46개 파일 | `BaseEntity`의 `createdAt`/`updatedAt` 기준. 영속 엔티티 전반 |
| `OffsetDateTime` | 2개 파일 | `TrackingResponse`, `TrackerDeliveryClient` — **외부 택배사 API 응답 파싱 DTO**. 영속 엔티티 아님 |
| `LocalDateTime` | **0건** | 기존 금지 규칙이 실제로 지켜지고 있음 |

정정 후:

> **Timezone**: DB `TIMESTAMPTZ`. 영속 엔티티·도메인 필드는 `ZonedDateTime` (`BaseEntity`가 기준). 외부 API 응답 파싱 DTO는 `OffsetDateTime` 허용 (shipping의 택배사 연동). `LocalDateTime`은 어느 계층에서도 금지.

**단순히 "ZonedDateTime 필수"로 뒤집지 않은 이유**: 그러면 shipping의 정상 코드 2개 파일이 규칙 위반으로 잡힙니다. 외부 API 경계에서 `OffsetDateTime`을 쓰는 것은 오히려 적절해서, 계층별로 나눠 기술했습니다.

## ✅ 테스트 방법
문서 변경이라 빌드 영향 없습니다.
1. `git diff develop...HEAD` 로 삭제된 블록이 전부 위 표의 범주에 해당하는지 확인
2. `/swagger-ui/index.html` 접속해 API 스펙이 실제로 뜨는지 확인
3. 타임존 규약이 실제 코드와 맞는지: `grep -rl "ZonedDateTime" backend/src/main/java | wc -l` (46), `grep -rl "OffsetDateTime" backend/src/main/java` (shipping 2개만), `grep -rn "LocalDateTime" backend/src/main/java` (0건)

## ⚠️ 리뷰어에게 전달 사항

`CLAUDE.md` §3이 `.gitmessage.txt` 템플릿 준수를 요구하는데 해당 파일이 저장소에 없습니다. 커밋 규칙 자체는 유효해 보여 삭제하지 않았으나, 템플릿 파일을 추가하거나 문장을 다듬는 편이 좋겠습니다. 이번 PR 범위 밖입니다.

## 📋 셀프 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석/로그를 제거했나요?
- [ ] 테스트를 작성/업데이트했나요? — 문서 변경으로 해당 없음
- [x] PR 제목이 명확한가요?
